### PR TITLE
feat: Issue-1: Fix response problem with enums

### DIFF
--- a/src/common/monitorstatus.rs
+++ b/src/common/monitorstatus.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
  */
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MonitorStatus {
-    #[serde(rename = "status")]
+    #[serde(rename = "current")]
     pub status: Status,
     #[serde(skip_serializing_if = "Option::is_none", rename = "lastSuccessfulTime")]
     pub last_successful_time: Option<DateTime<Utc>>,
@@ -70,6 +70,7 @@ impl MonitorStatus {
  *
  */
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", content = "information")]
 pub enum Status {
     Ok,
     Unknown,


### PR DESCRIPTION
Fixes a problem with the response when using enums in the response. The problem is that the response is not correctly deserialized when using enums when the response contains values.

The fix uses the serde attribute #[serde(tag = "status", content = "information")] to correctly deserialize the response.

Breaking changes: Changes the response format for monitorstatus.

Resolves: Issue-1