### PR TITLE
feat: Add meminfo service

### DIFF
--- a/resources/test/test_meminfo
+++ b/resources/test/test_meminfo
@@ -1,0 +1,55 @@
+MemTotal:       15538476 kB
+MemFree:         1286156 kB
+MemAvailable:    4491376 kB
+Buffers:          125648 kB
+Cached:          3307756 kB
+SwapCached:        41008 kB
+Active:          4631924 kB
+Inactive:        7763844 kB
+Active(anon):    3876520 kB
+Inactive(anon):  5676832 kB
+Active(file):     755404 kB
+Inactive(file):  2087012 kB
+Unevictable:        3604 kB
+Mlocked:             516 kB
+SwapTotal:       1998844 kB
+SwapFree:          13952 kB
+Zswap:                 0 kB
+Zswapped:              0 kB
+Dirty:                84 kB
+Writeback:             0 kB
+AnonPages:       8925856 kB
+Mapped:          1268732 kB
+Shmem:            590988 kB
+KReclaimable:     704540 kB
+Slab:            1169992 kB
+SReclaimable:     704540 kB
+SUnreclaim:       465452 kB
+KernelStack:       31728 kB
+PageTables:       120448 kB
+SecPageTables:         0 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     9768080 kB
+Committed_AS:   52569932 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:      158040 kB
+VmallocChunk:          0 kB
+Percpu:            14720 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+FileHugePages:         0 kB
+FilePmdMapped:         0 kB
+Unaccepted:            0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:     1891580 kB
+DirectMap2M:    11943936 kB
+DirectMap1G:     2097152 kB

--- a/src/common/configuration.rs
+++ b/src/common/configuration.rs
@@ -99,6 +99,8 @@ pub struct MonitoringConfig {
     pub monitors: Vec<Monitor>,
     #[serde(default = "default_as_true", rename = "showCpu")]
     pub show_cpu: bool,
+    #[serde(default = "default_as_true", rename = "showMem")]
+    pub show_mem: bool,    
 }
 
 impl MonitoringConfig {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -11,4 +11,4 @@ pub use crate::common::applicationerror::ApplicationError;
 pub use crate::common::monitorstatus::{MonitorStatus, Status};
 pub use crate::common::configuration::{Monitor, MonitorType, HttpMethod};
 pub use crate::common::args::ApplicationArguments;
-pub use crate::common::procsdata::ProcsCpuinfo;
+pub use crate::common::procsdata::{ProcsCpuinfo, ProcsMeminfo};

--- a/src/common/procsdata.rs
+++ b/src/common/procsdata.rs
@@ -47,4 +47,42 @@ impl ProcsCpuinfo {
     }
 }
 
+/**
+ * Memory information from /cat/meminfo
+ */
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcsMeminfo {
+    pub memtotal: Option<u64>,
+    pub memfree: Option<u64>,
+    pub memavailable: Option<u64>,
+    pub swaptotal: Option<u64>,
+    pub swapfree: Option<u64>,
+}
 
+impl ProcsMeminfo {
+
+    /**
+     * Create a new `Meminfo`.
+     *
+     * `memtotal`: The total memory.
+     * `memfree`: The free memory.
+     * `memavailable`: The available memory.
+     * `swaptotal`: The total swap.
+     * `swapfree`: The free swap.
+     */
+    pub fn new(
+        memtotal: Option<u64>,
+        memfree: Option<u64>,
+        memavailable: Option<u64>,
+        swaptotal: Option<u64>,
+        swapfree: Option<u64>,
+    ) -> ProcsMeminfo {
+        ProcsMeminfo {
+            memtotal,
+            memfree,
+            memavailable,
+            swaptotal,
+            swapfree,
+        }
+    }
+}

--- a/src/services/procs/meminfo.rs
+++ b/src/services/procs/meminfo.rs
@@ -1,0 +1,143 @@
+use std::{collections::HashMap, fs::File, io::{BufRead, BufReader}, sync::{Arc, Mutex}};
+use std::str::FromStr;
+
+use log::error;
+
+use crate::common::{ApplicationError, ProcsMeminfo};
+
+/**
+ * Meminfo.
+ * 
+ * This struct represents the meminfo data.
+ * 
+ */
+#[derive(Debug, Clone)]
+pub struct Meminfo {
+    pub procsdata: Arc<Mutex<ProcsMeminfo>>,
+}
+
+impl Meminfo {
+    /**
+     * Create a new `Meminfo`.
+     * 
+     * Returns a new `Meminfo`.
+     */
+    pub fn new() -> Meminfo {
+        Meminfo { 
+            procsdata: Arc::new(Mutex::new(ProcsMeminfo::new(None, None, None, None, None))),
+        }
+    }
+
+    /**
+     * Get and set the meminfo data.
+     * 
+     * Returns error if there is an error getting the lock or reading the data.
+     */
+    pub fn get_and_set_meminfo(self) -> Result<(), ApplicationError> {
+        let lock = self.procsdata.lock();
+        match lock {
+            Ok(mut procsdata) => {
+                let data = Meminfo::read_meminfo("/proc/meminfo");
+                match data {
+                    Ok(data) => {
+                        *procsdata = data;
+                    },
+                    Err(err) => {
+                        error!("Error reading cpuinfo: {err:?}");
+                        return Err(ApplicationError::new("Error getting procsdata lock"));
+                    }
+                }
+            },
+            Err(err) => {
+                error!("Error getting procsdata lock: {err:?}");
+                return Err(ApplicationError::new("Error getting procsdata lock"));
+            }
+        };        
+        Ok(())
+    }       
+
+    /**
+     * Read the meminfo file.
+     * 
+     * `file`: The file to read.
+     * 
+     * Returns the meminfo data or an error.
+     */
+    pub fn read_meminfo(file: &str) -> Result<ProcsMeminfo, ApplicationError> {
+        let meminfo_file = File::open(file);
+        let mut parts: HashMap<String, String> = HashMap::new();                
+        match meminfo_file {
+            Ok(file) => {
+                let reader = BufReader::new(file);
+                for line in reader.lines() {
+                    let line = Meminfo::get_line(line)?;                    
+                    let parts_data: Vec<&str> = line.split(':').collect();
+                    if parts_data.len() == 2 {
+                        parts.insert(parts_data[0].trim().to_string(), parts_data[1].replace("kB", "").trim().to_string());
+                    }                                                                                    
+                }
+            },
+            Err(err) => {
+                error!("Error reading meminfo: {:?}", err);
+                return Err(ApplicationError::new("Error reading meminfo"));
+            }
+        }
+        Ok(ProcsMeminfo::new(   
+            parts.get("MemTotal").and_then(|f| u64::from_str(f).ok()),
+            parts.get("MemFree").and_then(|f| u64::from_str(f).ok()),
+            parts.get("MemAvailable").and_then(|f| u64::from_str(f).ok()),
+            parts.get("SwapTotal").and_then(|f| u64::from_str(f).ok()),
+            parts.get("SwapFree").and_then(|f| u64::from_str(f).ok()),
+        ))
+    }
+
+    /**
+     * Get a line from the meminfo file.
+     * 
+     * `line`: The line to get.
+     * 
+     * Returns the line or an error.
+     * 
+     */
+    fn get_line(line: Result<String, std::io::Error>) -> Result<String, ApplicationError> {
+        match line {
+            Ok(line) => {
+                Ok(line)
+            },
+            Err(err) => {
+                Err(ApplicationError::new(format!("Error reading line: {err:?}").as_str()))
+            }
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_current_and_set_values() {
+        let meminfo = Meminfo::new();
+        let binding = meminfo.get_and_set_meminfo();
+        assert!(binding.is_ok());
+    }
+
+    #[test]
+    fn test_current() {
+        let binding = Meminfo::read_meminfo("/proc/meminfo");
+        assert!(binding.is_ok());
+    }
+
+    #[test]
+    fn test_read_cpuinfo() {
+        let binding = Meminfo::read_meminfo("resources/test/test_meminfo").unwrap();
+        assert_eq!(binding.memtotal, Some(15538476));
+        assert_eq!(binding.memfree, Some(1286156));
+        assert_eq!(binding.memavailable, Some(4491376));
+        assert_eq!(binding.swaptotal, Some(1998844));
+        assert_eq!(binding.swapfree, Some(13952));
+    }
+
+}

--- a/src/services/procs/mod.rs
+++ b/src/services/procs/mod.rs
@@ -1,3 +1,5 @@
 mod cpuinfo;
+mod meminfo;
 
 pub use crate::services::procs::cpuinfo::Cpuinfo;
+pub use crate::services::procs::meminfo::Meminfo;


### PR DESCRIPTION
Adds a new service to read the /proc/meminfo file and return the data as a JSON object. This service is used to monitor the memory usage of the system. Only five fields are returned: MemTotal, MemFree, MemAvailable, SwapTotal, and SwapFree. The data is returned at The meminfo endpoint.

Breaking changes: None

Resolves: Issue-6