### PR TITLE
feat: Issue-16: Store PID file in /var/run

### DIFF
--- a/src/common/args.rs
+++ b/src/common/args.rs
@@ -36,6 +36,6 @@ pub struct ApplicationArguments {
     pub stderr: String,
 
     /// pid file. Only used when daemonizing the application.
-    #[arg(short = 'p', long, default_value = "/tmp/monitoring-agent.pid")]
+    #[arg(short = 'p', long, default_value = "/var/run/monitoring-agent.pid")]
     pub pidfile: String,
 }

--- a/src/services/monitors/tcpmonitor.rs
+++ b/src/services/monitors/tcpmonitor.rs
@@ -154,9 +154,9 @@ mod test {
     async fn test_check_port_65000() {
         let status: Arc<Mutex<HashMap<String, MonitorStatus>>> =
             Arc::new(Mutex::new(HashMap::new()));
-        let mut monitor = TcpMonitor::new("localhost", 64999, "localhost", &status);
+        let mut monitor = TcpMonitor::new("localhost", 65000, "localhost", &status);
         monitor.check();
-        assert_eq!(status.lock().unwrap().get("localhost").unwrap().status, Status::Error { message: "Error connecting to localhost:64999 with error: Connection refused (os error 111)".to_string() });
+        assert_eq!(status.lock().unwrap().get("localhost").unwrap().status, Status::Error { message: "Error connecting to localhost:65000 with error: Connection refused (os error 111)".to_string() });
     }
 
     /**


### PR DESCRIPTION
Based on the file hierarchy standard
<https://www.pathname.com/fhs/2.2/fhs-5.13.html>. The default place to store the pid file should be /var/run. This commit changes the location of the pid file to /var/run/monitoring-agent.pid.

Additionally, also fix an error in the testing of the server.

Breaking changes: The location of the pid file has changed from /tmp/monitoring-agent.pid to /var/run/monitoring-agent.pid. This should not affect any functionality of the monitoring agent.

Resolves: #16