### PR TITLE
docs: Fix documentation in library

### DIFF
--- a/monitoring-agent-lib/src/common/mod.rs
+++ b/monitoring-agent-lib/src/common/mod.rs
@@ -1,6 +1,4 @@
-/*
- * Common functionality for the library.
-*/
+/// Structure for handling errors in the library 
 pub mod error;
 
 #[allow(clippy::module_name_repetitions)]

--- a/monitoring-agent-lib/src/lib.rs
+++ b/monitoring-agent-lib/src/lib.rs
@@ -1,5 +1,4 @@
-/*
- * Library for monitoring agent.
-*/
+/// Common functionality for the library.
 pub mod common;
+/// Structures and methods to read and parse /proc
 pub mod proc;

--- a/monitoring-agent-lib/src/proc/cpuinfo.rs
+++ b/monitoring-agent-lib/src/proc/cpuinfo.rs
@@ -12,12 +12,19 @@ use crate::common::CommonLibError;
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcsCpuinfo {
+    /// Onboard apicid of the cpu.
     pub apicid: Option<u8>,
+    /// Vendor id of the cpu e.g. AuthenticAMD.
     pub vendor_id:  Option<String>,
+    /// Authoritatively identifies the type of processor in the system.
     pub cpu_family:  Option<String>,
+    /// Model identifier of the cpu.
     pub model:  Option<String>,
+    /// Displays the common name of the processor, including its project name.
     pub model_name:  Option<String>,
+    /// Number of cores in the cpu.
     pub cpu_cores:  Option<u8>,
+    /// Speed of the cpu in Mhz.
     pub cpu_mhz:  Option<f32>,
 }
 

--- a/monitoring-agent-lib/src/proc/cpuinfo.rs
+++ b/monitoring-agent-lib/src/proc/cpuinfo.rs
@@ -14,6 +14,7 @@ use crate::common::CommonLibError;
 pub struct ProcsCpuinfo {
     /// Onboard apicid of the cpu.
     pub apicid: Option<u8>,
+    #[allow(clippy::doc_markdown)]
     /// Vendor id of the cpu e.g. AuthenticAMD.
     pub vendor_id:  Option<String>,
     /// Authoritatively identifies the type of processor in the system.

--- a/monitoring-agent-lib/src/proc/loadavg.rs
+++ b/monitoring-agent-lib/src/proc/loadavg.rs
@@ -11,11 +11,16 @@ use crate::common::CommonLibError;
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Loadavg {
+    /// The load average for the last minute.    
     pub loadavg1min: Option<f32>,
+    /// The load average for the last 5 minutes.
     pub loadavg5min:  Option<f32>,
     #[allow(clippy::similar_names)]
+    /// The load average for the last 10 minutes.
     pub loadavg10min:  Option<f32>,
+    /// The number of currently running processes.
     pub current_running_processes: Option<u32>,
+    /// The total number of processes.
     pub total_number_of_processes: Option<u32>
 }
 

--- a/monitoring-agent-lib/src/proc/meminfo.rs
+++ b/monitoring-agent-lib/src/proc/meminfo.rs
@@ -12,10 +12,15 @@ use crate::common::CommonLibError;
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcsMeminfo {
+    /// The total memory.
     pub memtotal: Option<u64>,
+    /// The free memory.
     pub memfree: Option<u64>,
+    /// The available memory.
     pub memavailable: Option<u64>,
+    /// The total swap.
     pub swaptotal: Option<u64>,
+    /// The free swap.
     pub swapfree: Option<u64>,
 }
 

--- a/monitoring-agent-lib/src/proc/mod.rs
+++ b/monitoring-agent-lib/src/proc/mod.rs
@@ -1,9 +1,10 @@
-/* 
- * Common structures for reading proc files.
- */
+/// Structure and methods to read and parse /proc/cpuinfo 
 pub mod cpuinfo;
+/// Structure and methods to read and parse /proc/meminfo 
 pub mod meminfo;
+/// Structure and methods to read and parse /proc/loadavg
 pub mod loadavg;
+/// Structure and methods to read and parse /proc/*/status 
 pub mod process;
 
 pub use crate::proc::cpuinfo::ProcsCpuinfo;


### PR DESCRIPTION
Fixes the documentation in the library to make it more clear and concise. Updates the documentation struct elements and adds more information to the documentation. The documentation now appears when the user runs `cargo doc`.

breaking changes: None

Resolves: #29