### PR TITLE
feat:Issue-22: Get list of all child processes

### DIFF
--- a/monitoring-agent-lib/resources/test/processes/2914/task/54112/status
+++ b/monitoring-agent-lib/resources/test/processes/2914/task/54112/status
@@ -1,0 +1,42 @@
+Name:	kworker/4:0-mm_percpu_wq
+Umask:	0000
+State:	I (idle)
+Tgid:	54112
+Ngid:	0
+Pid:	54112
+PPid:	2
+TracerPid:	0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
+FDSize:	64
+Groups:	 
+NStgid:	54112
+NSpid:	54112
+NSpgid:	0
+NSsid:	0
+Kthread:	1
+Threads:	1
+SigQ:	1/60395
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	0000000000000000
+SigIgn:	ffffffffffffffff
+SigCgt:	0000000000000000
+CapInh:	0000000000000000
+CapPrm:	000001ffffffffff
+CapEff:	000001ffffffffff
+CapBnd:	000001ffffffffff
+CapAmb:	0000000000000000
+NoNewPrivs:	0
+Seccomp:	0
+Seccomp_filters:	0
+Speculation_Store_Bypass:	thread vulnerable
+SpeculationIndirectBranch:	conditional enabled
+Cpus_allowed:	0010
+Cpus_allowed_list:	4
+Mems_allowed:	00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	6
+nonvoluntary_ctxt_switches:	0
+x86_Thread_features:	
+x86_Thread_features_locked:	


### PR DESCRIPTION
Implements functionality to return a list of all child processes of a given process. This is done by reading the status files under the task directory of the given process.

Adds additional documentation for the elements in the process struct.

Breaking changes: None

Resolves: #22