### PR TITLE
feat: Issue-38: Create rest endpoint for loadavg/current

### DIFF
--- a/monitoring-agent-daemon/src/api/loadavg.rs
+++ b/monitoring-agent-daemon/src/api/loadavg.rs
@@ -1,0 +1,20 @@
+use actix_web::{get, web, HttpResponse, Responder};
+
+use crate::api::StateApi;
+use crate::api::response::LoadavgResponse;
+
+/**
+ * Get current load average.
+ * 
+ * `state`: The state object.
+ * 
+ * Returns the load average or an error.
+ */
+#[get("/loadavg/current")]
+pub async fn get_current_loadavg(state: web::Data<StateApi>) -> impl Responder {
+    let loadavg = state.monitoring_service.get_current_loadavg();
+    match loadavg {
+        Ok(loadavg) => HttpResponse::Ok().json(LoadavgResponse::from_loadavg(&loadavg)),
+        Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
+    }
+}

--- a/monitoring-agent-daemon/src/api/mod.rs
+++ b/monitoring-agent-daemon/src/api/mod.rs
@@ -2,9 +2,12 @@ mod meminfo;
 mod state;
 mod response;
 mod cpuinfo;
+mod loadavg;
 
 pub use crate::api::meminfo::get_current_meminfo;
 pub use crate::api::cpuinfo::get_current_cpuinfo;
+pub use crate::api::loadavg::get_current_loadavg;
+
 
 #[allow(clippy::module_name_repetitions)]
 pub use crate::api::state::StateApi;

--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -1,4 +1,4 @@
-use monitoring_agent_lib::proc::{ProcsCpuinfo, ProcsMeminfo};
+use monitoring_agent_lib::proc::{ProcsLoadavg, ProcsCpuinfo, ProcsMeminfo};
 use serde::{Deserialize, Serialize};
 
 /**
@@ -137,6 +137,72 @@ impl CpuinfoResponse {
      */
     pub fn from_cpuinfo(procs_cpu_info: &[ProcsCpuinfo]) -> Vec<CpuinfoResponse> {
         procs_cpu_info.iter().map(|cpu_info| CpuinfoResponse::new(cpu_info.apicid, cpu_info.vendor_id.clone(), cpu_info.cpu_family.clone(), cpu_info.model.clone(), cpu_info.model_name.clone(), cpu_info.cpu_cores, cpu_info.cpu_mhz)).collect()
+    }    
+
+}
+
+/**
+ * The `LoadavgResponse` struct represents the response of the loadavg endpoint.
+ */
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::module_name_repetitions)]
+pub struct LoadavgResponse {
+    /// Load average last 1 minute.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "loadAvg1Min")]    
+    pub loadavg1min: Option<f32>,
+    /// Load average last 5 minutes.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "loadAvg5Min")]        
+    pub loadavg5min:  Option<f32>,
+    /// Load average last 10 minutes.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "loadAvg10Min")]        
+    pub loadavg10min:  Option<f32>,
+    /// The number of currently running processes.
+    pub current_running_processes: Option<u32>,
+    /// The total number of processes.
+    pub total_number_of_processes: Option<u32> 
+}
+
+impl LoadavgResponse {
+    /**
+     * Create a new `LoadavgResponse`.
+     *
+     * `loadavg1min`: The 1 minute load average.
+     * `loadavg5min`: The 5 minute load average.
+     * `loadavg10min`: The 10 minute load average.
+     * 
+     * Returns a new `CpuinfoResponse`.
+     */
+    #[allow(clippy::similar_names)]
+    pub fn new(        
+        loadavg1min: Option<f32>,
+        loadavg5min: Option<f32>,
+        loadavg10min: Option<f32>,
+        current_running_processes: Option<u32>,
+        total_number_of_processes: Option<u32>,
+    ) -> LoadavgResponse {
+        LoadavgResponse {
+            loadavg1min,
+            loadavg5min,
+            loadavg10min,
+            current_running_processes,
+            total_number_of_processes,
+        }
+    }
+
+    /**
+     * Create a new `LoadavgResponse` from a `Loadavg`.
+     *
+     * `procs_loadavg`: The `Loadavg` object.
+     * 
+     * Returns a new `LoadavgResponse`.
+     */
+    pub fn from_loadavg(procs_loadavg: &ProcsLoadavg) -> LoadavgResponse {
+        LoadavgResponse::new(
+            procs_loadavg.loadavg1min, 
+            procs_loadavg.loadavg5min, 
+            procs_loadavg.loadavg10min, 
+            procs_loadavg.current_running_processes, 
+            procs_loadavg.total_number_of_processes)
     }    
 
 }

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -58,6 +58,7 @@ async fn main() -> Result<(), std::io::Error> {
             .app_data(web::Data::new(StateApi::new(monitoring_service.clone())))
             .service(api::get_current_meminfo)   
             .service(api::get_current_cpuinfo)   
+            .service(api::get_current_loadavg)   
     })
     .bind((monitoring_config.server.ip, monitoring_config.server.port))?
     .run()

--- a/monitoring-agent-daemon/src/services/monitoringservice.rs
+++ b/monitoring-agent-daemon/src/services/monitoringservice.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use futures::Future;
 use log::{debug, error, info};
-use monitoring_agent_lib::proc::{ProcsCpuinfo, ProcsMeminfo};
+use monitoring_agent_lib::proc::{ProcsLoadavg, ProcsCpuinfo, ProcsMeminfo};
 use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{ApplicationError, MonitorStatus};
@@ -515,6 +515,23 @@ impl MonitoringService {
             }
         }
     }    
+
+    /**
+     * Get the current load average.
+     *
+     * result: The result of getting the load average information.
+     */
+    #[allow(clippy::unused_self)]
+    pub fn get_current_loadavg(&self) -> Result<ProcsLoadavg, ApplicationError> {
+        let loadavg = ProcsLoadavg::get_loadavg();
+        match loadavg {
+            Ok(loadavg) => Ok(loadavg),
+            Err(err) => {
+                error!("Error: {}", err.message);
+                Err(ApplicationError::new("Error getting loadavg"))                
+            }
+        }
+    }        
 }
 
 #[cfg(test)]

--- a/monitoring-agent-lib/src/proc/loadavg.rs
+++ b/monitoring-agent-lib/src/proc/loadavg.rs
@@ -10,7 +10,7 @@ use crate::common::CommonLibError;
  */
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Loadavg {
+pub struct ProcsLoadavg {
     /// The load average for the last minute.    
     pub loadavg1min: Option<f32>,
     /// The load average for the last 5 minutes.
@@ -24,10 +24,10 @@ pub struct Loadavg {
     pub total_number_of_processes: Option<u32>
 }
 
-impl Loadavg {
+impl ProcsLoadavg {
 
     /**
-     * Create a new `Loadavg`.
+     * Create a new `ProcsLoadavg`.
      *
      * `loadavg1min`: The load average for the last minute.
      * `loadavg5min`: The load average for the last 5 minutes.
@@ -35,7 +35,7 @@ impl Loadavg {
      * `current_running_processes`: The number of currently running processes.
      * `total_number_of_processes`: The total number of processes.
      * 
-     * Returns a new `Loadavg`.
+     * Returns a new `ProcsLoadavg`.
      * 
      */
     #[allow(clippy::similar_names)]
@@ -45,7 +45,7 @@ impl Loadavg {
                             current_running_processes: Option<u32>,
                             total_number_of_processes: Option<u32>
     ) -> Self {
-        Loadavg {
+        ProcsLoadavg {
             loadavg1min,
             loadavg5min,
             loadavg10min,
@@ -62,9 +62,9 @@ impl Loadavg {
      *  - If there is an error reading a line from the loadavg file.
      *  - If there is an error parsing the data from the loadavg file.
      */
-    pub fn get_loadavg() -> Result<Loadavg, CommonLibError> {
+    pub fn get_loadavg() -> Result<ProcsLoadavg, CommonLibError> {
         let loadavg_file = "/proc/loadavg";
-        Loadavg::read_loadavg(loadavg_file)
+        ProcsLoadavg::read_loadavg(loadavg_file)
     }    
 
     /**
@@ -79,7 +79,7 @@ impl Loadavg {
      *  - If there is an error reading a line from the loadavg file.
      *  - If there is an error parsing the data from the loadavg file.
      */
-    fn read_loadavg(file: &str) -> Result<Loadavg, CommonLibError> {
+    fn read_loadavg(file: &str) -> Result<ProcsLoadavg, CommonLibError> {
         let loadavg_file = File::open(file);
         match loadavg_file {
             Ok(file) => {
@@ -106,7 +106,7 @@ impl Loadavg {
   *  - If there is an error reading a line from the loadavg file.
   *  - If there is an error parsing the data from the loadavg file.
   */
-fn handle_loadavg_file(file: File) -> Result<Loadavg, CommonLibError> {
+fn handle_loadavg_file(file: File) -> Result<ProcsLoadavg, CommonLibError> {
     let mut reader = BufReader::new(file);
     let mut buffer = String::new();
     let data = reader.read_line(&mut buffer);
@@ -117,7 +117,7 @@ fn handle_loadavg_file(file: File) -> Result<Loadavg, CommonLibError> {
                 Some(process_parts) => process_parts.split('/').collect::<Vec<&str>>(),
                 None => return Err(CommonLibError::new("Error parsing loadavg")),
             };
-            Ok(Loadavg::new(
+            Ok(ProcsLoadavg::new(
                 main_cols.first().and_then(|f| f32::from_str(f).ok()),
                 main_cols.get(1).and_then(|f| f32::from_str(f).ok()),
                 main_cols.get(2).and_then(|f| f32::from_str(f).ok()),
@@ -139,13 +139,13 @@ mod test {
     
         #[test]
         fn test_current() {
-            let binding = Loadavg::get_loadavg();
+            let binding = ProcsLoadavg::get_loadavg();
             assert!(binding.is_ok());
         }
     
         #[test]
         fn test_read_predefined_cpuinfo() {
-            let binding = Loadavg::read_loadavg("resources/test/test_loadavg").unwrap();
+            let binding = ProcsLoadavg::read_loadavg("resources/test/test_loadavg").unwrap();
             assert_eq!(&binding.loadavg1min.unwrap(), &0.59);
             assert_eq!(&binding.loadavg5min.clone().unwrap(), &0.63);
             assert_eq!(&binding.loadavg10min.clone().unwrap(), &0.32);

--- a/monitoring-agent-lib/src/proc/mod.rs
+++ b/monitoring-agent-lib/src/proc/mod.rs
@@ -9,5 +9,5 @@ pub mod process;
 
 pub use crate::proc::cpuinfo::ProcsCpuinfo;
 pub use crate::proc::meminfo::ProcsMeminfo;
-pub use crate::proc::loadavg::Loadavg;
+pub use crate::proc::loadavg::ProcsLoadavg;
 pub use crate::proc::process::ProcsProcess;


### PR DESCRIPTION
Implements a rest endpoint for getting the current loadavg of the system. The endpoint is available at /loadavg/current and returns the current loadavg of the system.

Changes some code in the monitoring-agent-lib to make it more similar to the other code.

Breaking changes: None

Resolves: #38