### PR TITLE
feat:Issue-47: Create new process api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "request": "launch",
             "name": "Debug",
             "program": "${workspaceRoot}/target/debug/monitoring-agent-daemon",
-            "args": ["--config=/home/kjetil/code/monitoring_agent/resources/test/test_full_integration_test.json"],
+            "args": ["--config=/home/kjetil/code/monitoring_agent/monitoring-agent-daemon/resources/test/test_full_integration_test.json"],
             "cwd": "${workspaceRoot}",
             "sourceLanguages": [
                 "rust"

--- a/monitoring-agent-daemon/resources/test/logging.yml
+++ b/monitoring-agent-daemon/resources/test/logging.yml
@@ -5,6 +5,6 @@ appenders:
     kind: console
 
 root:
-  level: info
+  level: debug
   appenders:
     - stdout

--- a/monitoring-agent-daemon/src/api/mod.rs
+++ b/monitoring-agent-daemon/src/api/mod.rs
@@ -3,11 +3,12 @@ mod state;
 mod response;
 mod cpuinfo;
 mod loadavg;
+mod process;
 
 pub use crate::api::meminfo::get_current_meminfo;
 pub use crate::api::cpuinfo::get_current_cpuinfo;
 pub use crate::api::loadavg::get_current_loadavg;
-
+pub use crate::api::process::{get_processes, get_process, get_threads};
 
 #[allow(clippy::module_name_repetitions)]
 pub use crate::api::state::StateApi;

--- a/monitoring-agent-daemon/src/api/process.rs
+++ b/monitoring-agent-daemon/src/api/process.rs
@@ -1,0 +1,55 @@
+use actix_web::{get, web, HttpResponse, Responder};
+
+use crate::api::StateApi;
+
+use super::response::ProcessResponse;
+
+/**
+ * Get list of processes.
+ * 
+ * `state`: The state object.
+ * 
+ * Returns the current memory information or an error.
+ */
+#[get("/processes")]
+pub async fn get_processes(state: web::Data<StateApi>) -> impl Responder {
+    let procs = state.monitoring_service.get_processes();    
+    match procs {
+        Ok(procs) => HttpResponse::Ok().json(ProcessResponse::from_processes(&procs)),
+        Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
+    }
+}
+
+/**
+ * Get process.
+ * 
+ * `state`: The state object.
+ * 
+ * Returns the specified process.
+ */
+#[get("/processes/{pid}")]
+pub async fn get_process(state: web::Data<StateApi>, path: web::Path<u32>) -> impl Responder {
+    let pid: u32 = path.into_inner();
+    let procs = state.monitoring_service.get_process(pid);    
+    match procs {
+        Ok(procs) => HttpResponse::Ok().json(ProcessResponse::from_process(&procs)),
+        Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
+    }
+}
+
+/**
+ * Get threads.
+ * 
+ * `state`: The state object.
+ * 
+ * Returns the specified process.
+ */
+#[get("/processes/{pid}/threads")]
+pub async fn get_threads(state: web::Data<StateApi>, path: web::Path<u32>) -> impl Responder {
+    let pid: u32 = path.into_inner();
+    let procs = state.monitoring_service.get_process_threads(pid);    
+    match procs {
+        Ok(procs) => HttpResponse::Ok().json(ProcessResponse::from_processes(&procs)),
+        Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
+    }
+}

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -33,16 +33,21 @@ async fn main() -> Result<(), std::io::Error> {
             Err(std::io::Error::new(std::io::ErrorKind::Other, "Error loading configuration"))
         }
     }?;
-
-    let mut scheduling_service = SchedulingService::new(&monitoring_config);
-    match scheduling_service.start(args.test).await {
-        Ok(()) => {
-            info!("Scheduling service started!");
-        }
-        Err(err) => {
-            error!("Error starting scheduling service: {:?}", err);
-        }
-    }
+    /*
+     * Start the scheduling service.
+     */
+    let cloned_monitoring_config = monitoring_config.clone();
+    tokio::spawn(async move {
+        let mut scheduling_service = SchedulingService::new(&cloned_monitoring_config);
+        match scheduling_service.start(args.test).await {
+            Ok(()) => {
+                info!("Scheduling service started!");
+            }
+            Err(err) => {
+                error!("Error starting scheduling service: {:?}", err);
+            }
+        };
+    });
     /*
      * Initialize monitoring service.
      */

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -13,7 +13,7 @@ use crate::common::ApplicationArguments;
 use crate::api::StateApi;
 use crate::services::MonitoringService;
 
-#[actix_web::main]
+#[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     /*
      * Parse command line arguments.
@@ -35,7 +35,7 @@ async fn main() -> Result<(), std::io::Error> {
     }?;
 
     let mut scheduling_service = SchedulingService::new(&monitoring_config);
-    match scheduling_service.start(args.test) {
+    match scheduling_service.start(args.test).await {
         Ok(()) => {
             info!("Scheduling service started!");
         }
@@ -69,6 +69,9 @@ async fn main() -> Result<(), std::io::Error> {
             .service(api::get_current_meminfo)   
             .service(api::get_current_cpuinfo)   
             .service(api::get_current_loadavg)   
+            .service(api::get_processes)
+            .service(api::get_process)
+            .service(api::get_threads)
     })
     .bind((monitoring_config.server.ip, monitoring_config.server.port))?
     .run()

--- a/monitoring-agent-daemon/src/services/monitoringservice.rs
+++ b/monitoring-agent-daemon/src/services/monitoringservice.rs
@@ -1,5 +1,5 @@
 use log::error;
-use monitoring_agent_lib::proc::{ProcsLoadavg, ProcsCpuinfo, ProcsMeminfo};
+use monitoring_agent_lib::proc::{ProcsCpuinfo, ProcsLoadavg, ProcsMeminfo, ProcsProcess};
 
 use crate::common::ApplicationError;
 use crate::common::configuration::MonitoringConfig;
@@ -81,5 +81,70 @@ impl MonitoringService {
                 Err(ApplicationError::new("Error getting loadavg"))                
             }
         }
-    }        
+    }
+
+    /**
+     * Get the current processes.
+     * 
+     * result: The result of getting the current processes.
+     * 
+     * # Errors
+     * - If there is an error getting the processes.
+     */
+    #[allow(clippy::unused_self)]
+    pub fn get_processes(&self) -> Result<Vec<ProcsProcess>, ApplicationError> {
+        let processes = ProcsProcess::get_all_processes();
+        match processes {
+            Ok(processes) => Ok(processes),
+            Err(err) => {
+                error!("Error: {}", err.message);
+                Err(ApplicationError::new("Error getting processes"))                
+            }
+        }
+    }
+
+    /**
+     * Get the current process.
+     * 
+     * `pid`: The process id.
+     * 
+     * result: The result of getting the current process.
+     * 
+     * # Errors
+     * - If there is an error getting the process.
+     */
+    #[allow(clippy::unused_self)]
+    pub fn get_process(&self, pid: u32) -> Result<ProcsProcess, ApplicationError> {
+        let process = ProcsProcess::get_process(pid);
+        match process {
+            Ok(process) => Ok(process),
+            Err(err) => {
+                error!("Error: {}", err.message);
+                Err(ApplicationError::new("Error getting process"))                
+            }
+        }
+    }
+
+    /**
+     * Get the process threads.
+     * 
+     * `pid`: The process id.
+     * 
+     * result: The result of getting the current process.
+     * 
+     * # Errors
+     * - If there is an error getting the process.
+     */
+    #[allow(clippy::unused_self)]
+    pub fn get_process_threads(&self, pid: u32) -> Result<Vec<ProcsProcess>, ApplicationError> {
+        let threads = ProcsProcess::get_process_threads(pid);
+        match threads {
+            Ok(threads) => Ok(threads),
+            Err(err) => {
+                error!("Error: {}", err.message);
+                Err(ApplicationError::new("Error getting threads"))                
+            }
+        }
+    } 
+
 }

--- a/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
@@ -1,4 +1,5 @@
 
+use log::info;
 use log::{debug, error};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -109,7 +110,7 @@ impl TcpMonitor {
      *
      */
     pub fn check(&mut self) {
-        debug!("Checking monitor: {}", &self.name);
+        info!("Checking monitor: {}", &self.name);
         match std::net::TcpStream::connect(format!("{}:{}", &self.host, &self.port)) {
             Ok(tcp_stream) => {
                 TcpMonitor::close_connection(&tcp_stream);

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, future::Future, sync::{Arc, Mutex}, time::{Duration, Instant}};
 
 use log::{debug, error, info};
-use tokio::runtime::{Handle, Runtime};
 use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{configuration::MonitoringConfig, ApplicationError, HttpMethod, MonitorStatus};

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -440,49 +440,42 @@ mod test {
     /**
      * Test the monitoring service with both tcp monitors and http monitors.
      */
-    #[test]
-    fn test_monitoring_service() {
+    #[tokio::test]
+    async fn test_monitoring_service() {
         let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_full_integration_test.json").unwrap());
-        scheduling_service.start(true).unwrap();
+        let res = scheduling_service.start(true).await;
+        assert!(res.is_ok());
     }
 
     /**
      * Test the monitoring service with a tcp monitor.
      */
-    #[test]
-    fn test_monitoring_service_tcp() {
+    #[tokio::test]
+    async fn test_monitoring_service_tcp() {
         let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_tcp.json").unwrap());
-        scheduling_service.start(true).unwrap();
+        let res = scheduling_service.start(true).await;
+        assert!(res.is_ok());
     }
 
     /**
      * Test the monitoring service with an http monitor.
      */
-    #[test]
-    fn test_monitoring_service_http() {
+    #[tokio::test]
+    async fn test_monitoring_service_http() {
         let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_http.json").unwrap());
-        scheduling_service
-            .start(true)
-            .unwrap();
+        let res = scheduling_service.start(true).await;
+        assert!(res.is_ok());
     }
 
     /**
      * Test the monitoring service with an command monitor.
      */
-    #[test]
-    fn test_monitoring_service_command() {
+    #[tokio::test]
+    async fn test_monitoring_service_command() {
         let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_command.json").unwrap());
-        scheduling_service
-            .start(true)
-            .unwrap();
+        let res = scheduling_service.start(true).await;
+        assert!(res.is_ok());
     }
 
-    /**
-     * Test the http monitoring service with a tls configuration.
-     */
-    #[test]
-    fn test_monitoring_service_with_tls_config() {
-
-    }
 }
 

--- a/monitoring-agent-lib/src/proc/process.rs
+++ b/monitoring-agent-lib/src/proc/process.rs
@@ -153,8 +153,8 @@ impl ProcsProcess {
      * - If there is an error reading a line from the process file.
      * 
      */
-    pub fn get_child_processes(pid: u32) -> Result<Vec<ProcsProcess>, CommonLibError> {
-        ProcsProcess::read_child_processes(pid, "/proc")
+    pub fn get_process_threads(pid: u32) -> Result<Vec<ProcsProcess>, CommonLibError> {
+        ProcsProcess::read_process_threads(pid, "/proc")
     }
 
     /**
@@ -171,7 +171,7 @@ impl ProcsProcess {
      * - If there is an error reading a line from the process file.
      * 
      */
-    fn read_child_processes(pid: u32, path: &str) -> Result<Vec<ProcsProcess>, CommonLibError> {
+    fn read_process_threads(pid: u32, path: &str) -> Result<Vec<ProcsProcess>, CommonLibError> {
         let task_path = path.to_string() + "/" + &pid.to_string() + "/task";
         let task_paths = fs::read_dir(task_path);
         match task_paths {
@@ -423,6 +423,7 @@ pub enum ProcessState {
     Zombie,
     /// The process is idle.
     Idle,
+    /// The process state is unknown. This probably occurs if the state is not found in the enum.
     Unknown
 }
 
@@ -469,7 +470,7 @@ mod test {
 
     #[test]
     fn test_read_children() {
-        let processes = ProcsProcess::read_child_processes(2914, "resources/test/processes");
+        let processes = ProcsProcess::read_process_threads(2914, "resources/test/processes");
         println!("{:?}", processes);
         assert!(&processes.is_ok());
         let processes = processes.unwrap().clone();


### PR DESCRIPTION
Implements the new process api for the monitoring agent daemon. This api will allow the monitoring agent to query the system for process information like list all processes, get process by pid and get threads. Filtering will be implemented in a later commit.

Also fixes a bug with monitoring agent daemon not being able to start

Breaking changes: None

Resolves: #47