### PR TITLE
build:Issue-49: Fix duplicate build and test

### DIFF
--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -2,8 +2,6 @@ name: compile-test
 on:
   push:
     branches: []
-  pull_request:
-    branches: []
 env:
     RUST_BACKTRACE: full
     CARGO_TERM_COLOR: always


### PR DESCRIPTION
Changes the compile-test.yml to only build the project when pushing not when opening a pull request.

Breaking changes: None

Resolves: #49