### PR TITLE
feat:Issue-57:Add api endpoint to get monitor stat

### DIFF
--- a/monitoring-agent-daemon/src/api/mod.rs
+++ b/monitoring-agent-daemon/src/api/mod.rs
@@ -14,11 +14,13 @@ mod response;
 mod cpuinfo;
 mod loadavg;
 mod process;
+mod monitor;
 
 pub use crate::api::meminfo::get_current_meminfo;
 pub use crate::api::cpuinfo::get_current_cpuinfo;
 pub use crate::api::loadavg::get_current_loadavg;
 pub use crate::api::process::{get_processes, get_process, get_threads};
+pub use crate::api::monitor::get_monitor_status;
 
 #[allow(clippy::module_name_repetitions)]
 pub use crate::api::state::StateApi;

--- a/monitoring-agent-daemon/src/api/monitor.rs
+++ b/monitoring-agent-daemon/src/api/monitor.rs
@@ -1,0 +1,10 @@
+use actix_web::{get, web, HttpResponse, Responder};
+
+use crate::api::StateApi;
+use crate::api::response::MonitorResponse;
+
+#[get("/monitors/status")]
+pub async fn get_monitor_status(state: web::Data<StateApi>) -> impl Responder {
+    let monitor_statuses = state.monitoring_service.get_all_monitorstatuses();
+    HttpResponse::Ok().json(MonitorResponse::from_monitor_status_messages(&monitor_statuses))    
+}

--- a/monitoring-agent-daemon/src/common/monitorstatus.rs
+++ b/monitoring-agent-daemon/src/common/monitorstatus.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 
 /**
  * `MonitorStatus` struct
@@ -11,19 +10,15 @@ use serde::{Deserialize, Serialize};
  * - `last_error_time`: The last time the monitor encountered an error
  *
  */
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct MonitorStatus {
     /// The status of the monitor.
-    #[serde(rename = "status")]
     pub status: Status,
     /// The last time the monitor was successful.
-    #[serde(skip_serializing_if = "Option::is_none", rename = "lastSuccessfulTime")]
     pub last_successful_time: Option<DateTime<Utc>>,
     /// The last error message.
-    #[serde(skip_serializing_if = "Option::is_none", rename = "lastError")]
     pub last_error: Option<String>,
     /// The last time the monitor encountered an error.
-    #[serde(skip_serializing_if = "Option::is_none", rename = "lastErrorTime")]
     pub last_error_time: Option<DateTime<Utc>>,
 }
 
@@ -73,7 +68,7 @@ impl MonitorStatus {
  * - Error: The monitor has encountered an error. The error message is stored in the message field
  *
  */
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Status {
     /// The monitor is working correctly.
     Ok,

--- a/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
@@ -150,7 +150,6 @@ impl CommandMonitor {
 #[cfg(test)]
 mod test {
     use std::os::unix::process::ExitStatusExt;
-    use std::borrow::Cow;
 
     use super::*;
 

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -475,7 +475,8 @@ mod test {
      */
     #[tokio::test]
     async fn test_monitoring_service() {
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_full_integration_test.json").unwrap());
+        let status = Arc::new(Mutex::new(HashMap::new()));
+        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_full_integration_test.json").unwrap(), &status);
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }
@@ -485,7 +486,8 @@ mod test {
      */
     #[tokio::test]
     async fn test_monitoring_service_tcp() {
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_tcp.json").unwrap());
+        let status = Arc::new(Mutex::new(HashMap::new()));
+        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_tcp.json").unwrap(), &status);
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }
@@ -495,7 +497,8 @@ mod test {
      */
     #[tokio::test]
     async fn test_monitoring_service_http() {
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_http.json").unwrap());
+        let status = Arc::new(Mutex::new(HashMap::new()));
+        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_http.json").unwrap(), &status);
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }
@@ -505,7 +508,8 @@ mod test {
      */
     #[tokio::test]
     async fn test_monitoring_service_command() {
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_command.json").unwrap());
+        let status = Arc::new(Mutex::new(HashMap::new()));
+        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_command.json").unwrap(), &status);
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }


### PR DESCRIPTION
Adds an api endpoint to get the monitor status of the system. The endpoint is /monitors/status and returns the monitor statuses. Removes serde from non response objects.

Breaking changes: None

Resolves: #57