### PR TITLE
feat:Issue-42:Store the monitoring in db

### DIFF
--- a/monitoring-agent-daemon/Cargo.toml
+++ b/monitoring-agent-daemon/Cargo.toml
@@ -25,6 +25,8 @@ log = "0.4.22"                                                                  
 actix-web = { version = "4.8.0" }                                                       # For handling http requests.
 chrono = { version = "0.4.38", features = ["serde"]}                                    # For handling time.
 monitoring-agent-lib = { path = "../monitoring-agent-lib" }                             # For reading system information.
+mysql = "25.0.1"                                                                        # For handling mysql connections.
+mysql_common = { version = "0.32.4" }                                                   # For handling mysql connections.
 
 [package.metadata.deb]
 maintainer = "Kjetil Fjellheim <kjetil@forgottendonkey.net>"

--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -1,4 +1,7 @@
 {
+    "database": {
+        "url": "mysql://monitor-agent-rw:[vKsoUcgY0CqHfKU@planescape.forgottendonkey.com:3306/monitor-agent"
+    },
     "server": {
 	    "ip": "127.0.0.1",
 	    "port":65000
@@ -6,7 +9,7 @@
     "monitors":[
         {
             "name":"Apache TCP",
-            "schedule": "*/1 * * * * *",
+            "schedule": "*/5 * * * * *",
             "details": {
                 "type": "tcp",
                 "host": "127.0.0.1",
@@ -15,7 +18,7 @@
         },
         {
             "name":"Netbios TCP",
-            "schedule": "*/1 * * * * *",
+            "schedule": "*/5 * * * * *",
             "details": {
                 "type": "tcp",
                 "host": "127.0.0.1",
@@ -24,7 +27,7 @@
         },
         {
             "name":"Apache Http",
-            "schedule": "*/1 * * * * *",
+            "schedule": "*/5 * * * * *",
             "details": {
                 "type": "http",
                 "url": "http://localhost",
@@ -33,7 +36,7 @@
         },
         {
             "name":"Systemctl memcached",
-            "schedule": "*/1 * * * * *",
+            "schedule": "*/5 * * * * *",
             "details": {
                 "type": "command",
                 "command": "systemctl",

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -78,11 +78,30 @@ pub enum HttpMethod {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Monitor {
     /// The name of the monitor.
+    #[serde(rename = "name")]
     pub name: String,
     /// The schedule of the monitor.
+    #[serde(rename = "schedule")]
     pub schedule: String,
     /// The details of the monitor.
+    #[serde(rename = "details")]
     pub details: MonitorType,
+    /// The database store configuration.
+    #[serde(rename = "store", default = "default_database_store_level")]
+    pub store: DatabaseStoreLevel,
+}
+
+/**
+ * Database store level.
+ */
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum DatabaseStoreLevel {
+    /// Store nothing.
+    None,
+    /// Store all.
+    All,
+    /// Store only errors.
+    Errors,
 }
 
 /**
@@ -99,9 +118,14 @@ pub struct MonitoringConfig {
     /// The server configuration. Example ip and port where web services are made available.
     #[serde(rename = "server", default = "default_server")]
     pub server: ServerConfig,
+    /// The database configuration. If non is provided, then no storage is used.
+    #[serde(rename = "database")]
+    pub database: Option<DatabaseConfig>,
     /// The list of monitors.
     #[serde(rename = "monitors")]
-    pub monitors: Vec<Monitor>,   
+    pub monitors: Vec<Monitor>,
+
+
 }
 
 impl MonitoringConfig {
@@ -164,6 +188,15 @@ pub struct ServerConfig {
 }
 
 /**
+ * Database configuration.
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct DatabaseConfig {
+    /// The database url. Example <mysql://root:password@localhost:3307/db_name>
+    pub url: String,
+}
+
+/**
  * Default server configuration.
  * 
  * result: The default server configuration.
@@ -200,6 +233,12 @@ fn default_server_port() -> u16 {
  */
 fn default_server_ip() -> String {
     "127.0.0.1".to_string()
+}
+/**
+ * Default database store level.
+ */
+fn default_database_store_level() -> DatabaseStoreLevel {
+    DatabaseStoreLevel::Errors
 }
 
 #[cfg(test)]

--- a/monitoring-agent-daemon/src/services/databaseservice.rs
+++ b/monitoring-agent-daemon/src/services/databaseservice.rs
@@ -1,0 +1,103 @@
+use mysql::{self, Pool, TxOpts }; // Import the `query` function and the `exec` function
+use mysql::params;
+use mysql::prelude::Queryable;
+
+use crate::common::configuration::DatabaseConfig;
+use crate::common::Status;
+use crate::common::ApplicationError;
+
+/**
+ * `MariaDB` Service.
+ * 
+ * This struct represents a `MariaDB` service. It is used to interact with the `MariaDB` database.
+ * 
+ */
+#[derive(Debug)]
+pub struct MariaDbService {
+    /// The database connection pool.
+    pool: Pool
+}
+
+impl MariaDbService {
+    /**
+     * Create a new `MariaDB` service.
+     * 
+     * `database_config`: The database configuration.
+     * 
+     * Returns: A new `MariaDB` service.
+     * 
+     * Errors:
+     * - If there is an error creating the pool.
+     */
+    pub fn new(database_config: &DatabaseConfig) -> Result<MariaDbService, ApplicationError> {
+        /*
+         * Create pool
+         */
+        let pool = mysql::Pool::new(database_config.url.as_str()).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        /*
+         * Verify connection
+         */
+        let _ = pool.get_conn().map_err(|err| ApplicationError::new(&err.to_string()))?;
+
+        Ok(MariaDbService {
+            pool
+        })
+    }
+
+    /**
+     * Insert a monitor status into the database.
+     * 
+     * `name`: The name of the monitor.
+     * `status`: The status of the monitor.
+     * `message`: The message associated with the status.
+     * 
+     * Returns: Ok if the status was inserted successfully.
+     * 
+     * Errors:
+     * - If there is an error inserting the status.
+     * - If there is an error starting a transaction.
+     * - If there is an error committing the transaction.
+     * 
+     */
+    pub fn insert_monitor_status(&self, name: &str, status: &Status) -> Result<(), ApplicationError> {
+        let mut tx = self.pool.start_transaction(TxOpts::default()).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.exec_drop("INSERT INTO monitor_status (monitor_name, status, log_time, message) VALUES (:name, :status, now(3), :message)", params! {
+            "name" => &name,
+            "status" => MariaDbService::get_status_db_repr(status),
+            "message" => MariaDbService::get_message(status),
+        }).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.commit().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        Ok(())
+    }
+
+    /**
+     * Get the database representation of the status.
+     * 
+     * `status`: The status to get the database representation of.
+     * 
+     * Returns: The database representation.
+     * 
+     */
+    fn get_status_db_repr(status: &Status) -> String {
+        match &status {
+            Status::Error { message: _ } => "ERROR".to_string(),
+            Status::Ok => "OK".to_string(),
+            Status::Unknown => "UNKNOWN".to_string(),
+        }
+    }
+
+    /**
+     * Get the message from the status.
+     *
+     * `status`: The status to get the message from.
+     *
+     * Returns: The message.
+     *
+     */
+    fn get_message(status: &Status) -> Option<String> {
+        match status {
+            Status::Error { message } => Some(message.clone()),
+            _ => None,
+        }
+    }    
+}

--- a/monitoring-agent-daemon/src/services/mod.rs
+++ b/monitoring-agent-daemon/src/services/mod.rs
@@ -4,11 +4,14 @@
  * `monitors`: The monitors contains monitors used to verify the status of the system.
  * `monitoringservice`: Handles the web service requests.
  * `schedulingservice`: Handles the scheduling of the monitoring tasks.
+ * `databaseservice`: Handles the database operations.
  */
 mod monitors;
 mod monitoringservice;
 mod schedulingservice;
+mod databaseservice;
 
 pub use monitoringservice::MonitoringService;
 pub use schedulingservice::SchedulingService;
+pub use databaseservice::MariaDbService;
 


### PR DESCRIPTION
Stores the monitoring in the database. This will store it in a mariadb/mysql database. The column names
- id - autoincrement
- log_time - always store as now(3)
- message - If error then include message.
- monitor_name - Monitor name
- status - Status of the monitor

If the configuration is set to store in the database then it will store the monitoring in the database, else it will not. Currently, the configuration allows for each monitor to decide if it should store in the database or not, but this is not implemented yet.

Breaking changes: None

Resolves: #42