### PR TITLE
feat:Issue-61: Fix code duplication in monitors

### DIFF
--- a/monitoring-agent-daemon/src/services/monitors/common.rs
+++ b/monitoring-agent-daemon/src/services/monitors/common.rs
@@ -1,0 +1,81 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use log::{debug, error};
+
+use crate::{common::{MonitorStatus, Status}, services::MariaDbService};
+
+pub trait Monitor {
+    
+    /**
+     * Get the name of the monitor.
+     *
+     * Returns: The name of the monitor.
+     */
+    fn get_name(&self) -> &str;
+
+    /**
+     * Get the status of the monitor.
+     *
+     * Returns: The status of the monitor.
+     */
+    fn get_status(&self) -> Arc<Mutex<HashMap<String, MonitorStatus>>>;
+
+    /**
+     * Get the database service.
+     *
+     * Returns: The database service.
+     */
+    fn get_database_service(&self) -> Arc<Option<MariaDbService>>;
+
+    /**
+     * Set the status of the monitor.
+     *
+     * `new_status`: The new status.
+     *
+     */
+    fn set_status(&mut self, new_status: &Status) {
+        self.insert_monitor_status(new_status);
+        let status = self.get_status();
+        match status.lock() {
+            Ok(mut monitor_lock) => {
+                debug!(
+                    "Setting monitor status for {} to: {:?}",
+                    self.get_name(), &status
+                );
+                let Some(monitor_status) = monitor_lock.get_mut(self.get_name()) else {
+                    error!("Monitor status not found for: {}", &self.get_name());
+                    return;
+                };
+                monitor_status.set_status(new_status);
+            }
+            Err(err) => {
+                error!("Error updating monitor status: {:?}", err);
+            }
+        };
+    }
+
+   /**
+     * Insert the monitor status into the database.
+     *
+     * status: The status to insert.
+     *
+     */
+    fn insert_monitor_status(&mut self, status: &Status) {
+        let database_service = self.get_database_service();
+        if database_service.is_some() {
+            let database_service = database_service.as_ref();
+            if database_service.is_some() {
+                let database_service = database_service.as_ref().unwrap();
+                match database_service.insert_monitor_status(
+                    self.get_name(),
+                    &status.clone(),
+                ) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        error!("Error inserting monitor status: {:?}", err);
+                    }
+                }
+            }
+        }
+    }  
+}

--- a/monitoring-agent-daemon/src/services/monitors/mod.rs
+++ b/monitoring-agent-daemon/src/services/monitors/mod.rs
@@ -5,10 +5,12 @@
  * `httpmonitor`: Monitor that checks the status of an HTTP service.
  * `tcpmonitor`: Monitor that checks the status of a TCP service. 
  */
+mod common;
 mod commandmonitor;
 mod httpmonitor;
 mod tcpmonitor;
 
+pub use common::Monitor;
 pub use commandmonitor::CommandMonitor;
 pub use httpmonitor::HttpMonitor;
 pub use tcpmonitor::TcpMonitor;


### PR DESCRIPTION
Fixes code duplication by moving common code to the monitor trait. This will make it easier to add new monitors in the future.

Breaking changes: None

Resolves: #61