### PR TITLE
feat: Issue-66: Add monitor name to response

### DIFF
--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -354,6 +354,9 @@ impl ProcessStateResponse {
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MonitorResponse {
+    /// Name of the monitor.
+    #[serde(rename = "name")]
+    name: String,
     /// The status of the monitor.
     #[serde(rename = "status")]
     status: MonitorStatusResponse,
@@ -372,6 +375,7 @@ impl MonitorResponse {
     /**
      * Create a new `MonitorResponse`.
      * 
+     * `name`: The name of the monitor.
      * `status`: The status of the monitor.
      * `last_successful_time`: The last time the monitor was successful.
      * `last_error`: The last error message.
@@ -379,12 +383,14 @@ impl MonitorResponse {
      * 
      */
     pub fn new(
+        name: String,
         status: MonitorStatusResponse,
         last_successful_time: Option<DateTime<Utc>>,
         last_error: Option<String>,
         last_error_time: Option<DateTime<Utc>>,
     ) -> MonitorResponse {
         MonitorResponse {
+            name,
             status,
             last_successful_time,
             last_error,
@@ -402,6 +408,7 @@ impl MonitorResponse {
      */
     pub fn from_monitor_status_message(monitor_status: &MonitorStatus) -> MonitorResponse {
         MonitorResponse::new(
+            monitor_status.name.clone(),
             MonitorStatusResponse::from_status(&monitor_status.status),
             monitor_status.last_successful_time,
             monitor_status.last_error.clone(),

--- a/monitoring-agent-daemon/src/common/monitorstatus.rs
+++ b/monitoring-agent-daemon/src/common/monitorstatus.rs
@@ -12,6 +12,8 @@ use chrono::{DateTime, Utc};
  */
 #[derive(Debug, Clone, PartialEq)]
 pub struct MonitorStatus {
+    /// The name of the monitor.
+    pub name: String,
     /// The status of the monitor.
     pub status: Status,
     /// The last time the monitor was successful.
@@ -29,8 +31,9 @@ impl MonitorStatus {
      * `status`: The status of the monitor.
      *
      */
-    pub fn new(status: Status) -> MonitorStatus {
+    pub fn new(name: String, status: Status) -> MonitorStatus {
         MonitorStatus {
+            name,
             status,
             last_successful_time: None,
             last_error: None,

--- a/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
@@ -59,7 +59,7 @@ impl CommandMonitor {
         let status_lock = status.lock();
         match status_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(),Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating command monitor: {:?}", err);

--- a/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
@@ -139,7 +139,7 @@ impl HttpMonitor {
         let monitor_lock = status.lock();
         match monitor_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating HTTP monitor: {:?}", err);

--- a/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
@@ -60,7 +60,7 @@ impl TcpMonitor {
         let status_lock = status.lock();
         match status_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating command monitor: {:?}", err);


### PR DESCRIPTION
Adds monitor name to the response of the monitor status endpoint. This will make it easier to identify which monitor is failing.

Breaking changes: None

Resolves: #66