### PR TITLE
feat:Issue-56:Add loadaverage monitor

### DIFF
--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -43,6 +43,17 @@
                 "args": ["show", "memcached.service", "--property=ActiveState"],
                 "expected": "ActiveState=active\n"
             }
+        },
+        {
+            "name":"Loadavg",
+            "schedule": "*/5 * * * * *",
+            "details": {
+                "type": "loadAvg",
+                "threshold1min": 2.0,
+                "threshold5min": 2.0,
+                "threshold10min": 2.0,
+                "storeValues": true
+            }
         }
     ]
 }

--- a/monitoring-agent-daemon/src/common/applicationerror.rs
+++ b/monitoring-agent-daemon/src/common/applicationerror.rs
@@ -20,4 +20,8 @@ impl ApplicationError {
             message: message.to_string(),
         }
     }
+
+    pub fn get_message(&self) -> String {
+        self.message.clone()
+    }
 }

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -9,10 +9,11 @@ use crate::common::ApplicationError;
  *
  * This enum represents the different types of monitors that can be used.
  *
- * Tcp: Monitor a TCP connection.
- * Http: Monitor an HTTP connection.
- * Sql: Monitor a SQL connection.
- * Command: Monitor a command.
+ * `Tcp`: Monitor a TCP connection.
+ * `Http`: Monitor an HTTP connection.
+ * `Sql`: Monitor a SQL connection.
+ * `Command`: Monitor a command.
+ * `LoadAvg`: Monitor the load average of the system. Can only be one.
  *
  */
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -49,6 +50,16 @@ pub enum MonitorType {
         #[serde(skip_serializing_if = "Option::is_none")]
         expected: Option<String>,
     },
+    LoadAvg {
+        #[serde(skip_serializing_if = "Option::is_none", rename = "threshold1min")]
+        threshold_1min: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "threshold5min")]
+        threshold_5min: Option<f32>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "threshold10min")]
+        threshold_10min: Option<f32>,
+        #[serde(rename = "storeValues", default = "default_as_false")]
+        store_values: bool,    
+    },    
 }
 
 /**

--- a/monitoring-agent-daemon/src/services/monitors/common.rs
+++ b/monitoring-agent-daemon/src/services/monitors/common.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::{Arc, Mutex}};
 
 use log::{debug, error};
 
-use crate::{common::{configuration::DatabaseStoreLevel, MonitorStatus, Status}, services::MariaDbService};
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::MariaDbService};
 
 pub trait Monitor {
     
@@ -33,6 +33,16 @@ pub trait Monitor {
      * Returns: The database store level.
      */
     fn get_database_store_level(&self) -> DatabaseStoreLevel;
+    
+    /**
+     * Check the status of the monitor.
+     * 
+     * Returns: Ok if the monitor is running successfully.
+     * 
+     * Errors:
+     * - If there is an error checking the monitor.
+     */
+    async fn check(&mut self) -> Result<(), ApplicationError>;
 
     /**
      * Set the status of the monitor.

--- a/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
@@ -237,50 +237,6 @@ impl HttpMonitor {
     }
 
     /**
-     * Check the monitor.
-     *
-     */
-    pub async fn check(&mut self) -> Result<(), ApplicationError> {
-        debug!("Checking monitor: {}", &self.name);
-        /*
-         * Set http method.
-         */
-        let request_builder = match &self.method {
-            HttpMethod::Get => self.client.get(&self.url),
-            HttpMethod::Post => self.client.post(&self.url),
-            HttpMethod::Put => self.client.put(&self.url),
-            HttpMethod::Delete => self.client.delete(&self.url),
-            HttpMethod::Option => self.client.request(reqwest::Method::OPTIONS, &self.url),
-            HttpMethod::Head => self.client.head(&self.url),
-        };
-        /*
-         * Set headers.
-         */
-        let request_builder = request_builder.headers(HttpMonitor::get_headers(&self.headers)?);
-        /*
-         * Set body.
-         */
-        let request_builder = match &self.body {
-            Some(body) => request_builder.body(body.clone()),
-            None => request_builder,
-        };
-        /*
-         * Set timeout.
-         */
-        let request_builder = request_builder.timeout(Duration::from_secs(5));
-        /*
-         * Send request.
-         */
-        let req_response = request_builder.send().await;
-        /*
-         * Check response and set status in the monitor.
-         */
-        self.check_response_and_set_status(req_response);
-        debug!("Monitor checked: {}", &self.name);
-        Ok(())
-    }
-
-    /**
      * Check the response and set the status of the monitor.
      *
      * `response`: The response from the request.
@@ -431,12 +387,58 @@ impl super::Monitor for HttpMonitor {
     fn get_database_store_level(&self) -> DatabaseStoreLevel {
         self.database_store_level.clone()
     }
+
+    /**
+     * Check the monitor.
+     *
+     */
+    async fn check(&mut self) -> Result<(), ApplicationError> {
+        debug!("Checking monitor: {}", &self.name);
+        /*
+         * Set http method.
+         */
+        let request_builder = match &self.method {
+            HttpMethod::Get => self.client.get(&self.url),
+            HttpMethod::Post => self.client.post(&self.url),
+            HttpMethod::Put => self.client.put(&self.url),
+            HttpMethod::Delete => self.client.delete(&self.url),
+            HttpMethod::Option => self.client.request(reqwest::Method::OPTIONS, &self.url),
+            HttpMethod::Head => self.client.head(&self.url),
+        };
+        /*
+         * Set headers.
+         */
+        let request_builder = request_builder.headers(HttpMonitor::get_headers(&self.headers)?);
+        /*
+         * Set body.
+         */
+        let request_builder = match &self.body {
+            Some(body) => request_builder.body(body.clone()),
+            None => request_builder,
+        };
+        /*
+         * Set timeout.
+         */
+        let request_builder = request_builder.timeout(Duration::from_secs(5));
+        /*
+         * Send request.
+         */
+        let req_response = request_builder.send().await;
+        /*
+         * Check response and set status in the monitor.
+         */
+        self.check_response_and_set_status(req_response);
+        debug!("Monitor checked: {}", &self.name);
+        Ok(())
+    }    
      
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use crate::services::monitors::Monitor;
 
     use reqwest::header::HeaderValue;
 

--- a/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
@@ -1,0 +1,396 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use log::error;
+use monitoring_agent_lib::proc::ProcsLoadavg;
+
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::MariaDbService};
+
+use super::Monitor;
+
+#[derive(Debug, Clone)]
+pub struct LoadAvgMonitor {
+    /// The name of the monitor.
+    pub name: String,
+    /// Max load average for 1 minute.
+    pub loadavg1min_max: Option<f32>,
+    /// Max load average for 5 minutes.
+    pub loadavg5min_max: Option<f32>,
+    /// Max load average for 10 minutes.
+    pub loadavg10min_max: Option<f32>,
+    /// The status of the monitor.
+    pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
+    /// The database service.
+    database_service: Arc<Option<MariaDbService>>,
+    /// The database store level.
+    database_store_level: DatabaseStoreLevel,
+    /// The current load average.
+    store_current_loadavg: bool,              
+}
+
+impl LoadAvgMonitor {
+
+    /**
+     * Create a new load average monitor.
+     * 
+     * `name`: The name of the monitor.
+     * `loadavg1min_max`: The max load average for 1 minute.
+     * `loadavg5min_max`: The max load average for 5 minutes.
+     * `loadavg10min_max`: The max load average for 10 minutes.
+     * `status`: The status of the monitor.
+     * `database_service`: The database service.
+     * `database_store_level`: The database store level.
+     * `store_current_loadavg`: Store the current load average.
+     * 
+     * Returns: A new load average monitor.
+     * 
+     */
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::similar_names)]    
+    pub fn new(
+        name: &str,
+        loadavg1min_max: Option<f32>,
+        loadavg5min_max: Option<f32>,
+        loadavg10min_max: Option<f32>,
+        status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
+        database_service: &Arc<Option<MariaDbService>>,
+        database_store_level: DatabaseStoreLevel,
+        store_current_loadavg: bool,
+    ) -> LoadAvgMonitor {
+
+        let status_lock = status.lock();
+        match status_lock {
+            Ok(mut lock) => {
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+            }
+            Err(err) => {
+                error!("Error creating loadavg monitor: {:?}", err);
+            }
+        }
+
+        LoadAvgMonitor {
+            name: name.to_string(),
+            loadavg1min_max,
+            loadavg5min_max,
+            loadavg10min_max,
+            status: status.clone(),
+            database_service: database_service.clone(),
+            database_store_level,
+            store_current_loadavg,
+        }
+    }
+
+    /**
+     * Check the load average.
+     * 
+     * `loadavg`: The current load average.
+     * 
+     */
+    #[allow(clippy::similar_names)]         
+    fn check_loadavg(&mut self, loadavg: &ProcsLoadavg) {    
+        let status_1min = LoadAvgMonitor::check_loadavg_values(self.loadavg1min_max, loadavg.loadavg1min);
+        let status_5min = LoadAvgMonitor::check_loadavg_values(self.loadavg5min_max, loadavg.loadavg5min);
+        let status_10min = LoadAvgMonitor::check_loadavg_values(self.loadavg10min_max, loadavg.loadavg10min);
+        
+        if status_1min != Status::Ok || status_5min != Status::Ok || status_10min != Status::Ok {
+            self.set_status(&Status::Error {
+                message: format!(
+                    "Load average check failed: 1min: {status_1min:?}, 5min: {status_5min:?}, 10min: {status_10min:?}"
+                ),
+            });
+        } else {
+            self.set_status(&Status::Ok);
+        }
+    }
+
+    /**
+     * Check the load average values.
+     * 
+     * `max`: The max load average.
+     * `current`: The current load average.
+     * 
+     * Returns: The status of the check.
+     * 
+     */
+    fn check_loadavg_values(max: Option<f32>, current: Option<f32>) -> Status {
+        let Some(current) = current else { return Status::Ok };
+        let Some(max) = max else { return Status::Ok };
+            
+        if current > max {
+            return Status::Error {
+                message: format!(
+                    "Load average {current} is greater than max load average {max}"
+                ),
+            };
+        }
+        Status::Ok       
+    }
+
+    /**
+     * Check and store the current load average.
+     * 
+     * `loadavg`: The current load average.
+     * 
+     * 
+     */
+    fn check_store_current_loadavg(&self, loadavg: &ProcsLoadavg) {
+        if self.store_current_loadavg {
+            self.store_current_loadavg(loadavg);
+        }           
+    }
+    
+    /**
+     * Store the current load average.
+     * 
+     * `loadavg`: The current load average.
+     */
+    fn store_current_loadavg(&self, loadavg: &ProcsLoadavg) {
+        match self.database_service.as_ref() {            
+            Some(database_service) => {
+                match database_service.store_loadavg(loadavg) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        error!("Error storing load average: {:?}", err);
+                    }
+                }
+            }
+            None => {}
+        }        
+    }
+}
+
+/**
+ * Implement the `Monitor` trait for `LoadAvgMonitor`.
+ */
+impl super::Monitor for LoadAvgMonitor {
+    /**
+     * Get the name of the monitor.
+     *
+     * Returns: The name of the monitor.
+     */
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /**
+     * Get the status of the monitor.
+     *
+     * Returns: The status of the monitor.
+     */
+    fn get_status(&self) -> Arc<Mutex<HashMap<String, MonitorStatus>>> {
+        self.status.clone()
+    }
+
+    /**
+     * Get the database service.
+     *
+     * Returns: The database service.
+     */
+    fn get_database_service(&self) -> Arc<Option<MariaDbService>> {
+        self.database_service.clone()
+    }
+
+    /**
+     * Get the database store level.
+     *
+     * Returns: The database store level.
+     */
+    fn get_database_store_level(&self) -> DatabaseStoreLevel {
+        self.database_store_level.clone()
+    }
+
+    /**
+     * Check the monitor.
+     */
+    async fn check(&mut self) -> Result<(), ApplicationError> {
+        let loadavg = ProcsLoadavg::get_loadavg();
+        match loadavg {
+            Ok(loadavg) => {
+                self.check_store_current_loadavg(&loadavg);
+                self.check_loadavg(&loadavg);
+            }
+            Err(err) => {
+                error!("Error getting load average: {:?}", err);
+            }
+        }                    
+        Ok(())
+    }    
+     
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, sync::{Arc, Mutex}};
+    use crate::services::monitors::LoadAvgMonitor;
+
+    use super::Monitor;
+
+    /**
+     * Test the check_loadavg_values function.'
+     * 
+     * Test the following scenarios:
+     * - Load average is equal to max load average.
+     * - Load average is higher than max load average.
+     * - Load average is max has value, but none is retrieved.
+     * - Load average is max is None, but load average has value.
+     * - Load average and max load average are None.
+     */
+    #[test]
+    fn test_check_loadavg_values() {
+        let status = LoadAvgMonitor::check_loadavg_values(Some(1.0), Some(1.0));
+        assert_eq!(status, super::Status::Ok);
+
+        let status = LoadAvgMonitor::check_loadavg_values(Some(1.0), Some(2.0));
+        assert_eq!(status, super::Status::Error {
+            message: "Load average 2 is greater than max load average 1".to_string()
+        });
+
+        let status: crate::common::Status = LoadAvgMonitor::check_loadavg_values(Some(1.0), None);
+        assert_eq!(status, super::Status::Ok);
+
+        let status = LoadAvgMonitor::check_loadavg_values(None, Some(1.0));
+        assert_eq!(status, super::Status::Ok);
+
+        let status = LoadAvgMonitor::check_loadavg_values(None, None);
+        assert_eq!(status, super::Status::Ok);
+    }
+
+    /**
+     * Test the check_loadavg function.
+     * 
+     * Test the following scenarios:
+     * - Load average is lower on all.
+     */
+    #[test]
+    fn test_check_loadavg_lower_on_all() {
+        // Test success. Loadaverage lower on all
+        let mut monitor = super::LoadAvgMonitor::new(
+            "test",
+            Some(1.0),
+            Some(2.0),
+            Some(3.0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            super::DatabaseStoreLevel::None,
+            false,
+        );
+
+        let loadavg = monitoring_agent_lib::proc::ProcsLoadavg {
+            loadavg1min: Some(1.0),
+            loadavg5min: Some(2.0),
+            loadavg10min: Some(3.0),
+            current_running_processes: Some(1),
+            total_number_of_processes: Some(10)
+        };
+
+        monitor.check_loadavg(&loadavg);
+
+        let status = monitor.get_status();
+        let status = status.lock().unwrap();
+        assert_eq!(status.get("test").unwrap().status, super::Status::Ok);
+    }
+
+    /**
+     * Test the check_loadavg function.
+     * 
+     * Test the following scenarios:
+     * - Load average is higher on 1 minute.
+     */
+    #[test]
+    fn test_check_loadavg_1min_higher() {
+        // Test success. Loadaverage lower on all
+        let mut monitor = super::LoadAvgMonitor::new(
+            "test",
+            Some(1.0),
+            Some(2.0),
+            Some(3.0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            super::DatabaseStoreLevel::None,
+            false,
+        );
+
+        let loadavg = monitoring_agent_lib::proc::ProcsLoadavg {
+            loadavg1min: Some(1.1),
+            loadavg5min: Some(2.0),
+            loadavg10min: Some(3.0),
+            current_running_processes: Some(1),
+            total_number_of_processes: Some(10)
+        };
+
+        monitor.check_loadavg(&loadavg);
+
+        let status = monitor.get_status();
+        let status = status.lock().unwrap();
+        assert_eq!(status.get("test").unwrap().status, super::Status::Error { message: "Load average check failed: 1min: Error { message: \"Load average 1.1 is greater than max load average 1\" }, 5min: Ok, 10min: Ok".to_string() } );
+    }
+
+    /**
+     * Test the check_loadavg function.
+     * 
+     * Test the following scenarios:
+     * - Load average is higher on 5 minutes.
+     */
+    #[test]
+    fn test_check_loadavg_5min_higher() {
+        // Test success. Loadaverage lower on all
+        let mut monitor = super::LoadAvgMonitor::new(
+            "test",
+            Some(1.0),
+            Some(2.0),
+            Some(3.0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            super::DatabaseStoreLevel::None,
+            false,
+        );
+
+        let loadavg = monitoring_agent_lib::proc::ProcsLoadavg {
+            loadavg1min: Some(1.0),
+            loadavg5min: Some(2.1),
+            loadavg10min: Some(3.0),
+            current_running_processes: Some(1),
+            total_number_of_processes: Some(10)
+        };
+
+        monitor.check_loadavg(&loadavg);
+
+        let status = monitor.get_status();
+        let status = status.lock().unwrap();
+        assert_eq!(status.get("test").unwrap().status, super::Status::Error { message: "Load average check failed: 1min: Ok, 5min: Error { message: \"Load average 2.1 is greater than max load average 2\" }, 10min: Ok".to_string() } );
+    }
+
+    /**
+     * Test the check_loadavg function.
+     * 
+     * Test the following scenarios:
+     * - Load average is higher on 10 minutes.
+     */ 
+    #[test]
+    fn test_check_loadavg_10min_higher() {
+        // Test success. Loadaverage lower on all
+        let mut monitor = super::LoadAvgMonitor::new(
+            "test",
+            Some(1.0),
+            Some(2.0),
+            Some(3.0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            super::DatabaseStoreLevel::None,
+            false,
+        );
+
+        let loadavg = monitoring_agent_lib::proc::ProcsLoadavg {
+            loadavg1min: Some(1.0),
+            loadavg5min: Some(2.0),
+            loadavg10min: Some(3.1),
+            current_running_processes: Some(1),
+            total_number_of_processes: Some(10)
+        };
+
+        monitor.check_loadavg(&loadavg);
+
+        let status = monitor.get_status();
+        let status = status.lock().unwrap();
+        assert_eq!(status.get("test").unwrap().status, super::Status::Error { message: "Load average check failed: 1min: Ok, 5min: Ok, 10min: Error { message: \"Load average 3.1 is greater than max load average 3\" }".to_string() } );
+    }        
+}

--- a/monitoring-agent-daemon/src/services/monitors/mod.rs
+++ b/monitoring-agent-daemon/src/services/monitors/mod.rs
@@ -1,16 +1,20 @@
 /**
  * Modules for monitoring services. 
  * 
+ * `common`: Common functionality for monitors.
  * `commandmonitor`: Monitor that runs a command and checks the output.
  * `httpmonitor`: Monitor that checks the status of an HTTP service.
  * `tcpmonitor`: Monitor that checks the status of a TCP service. 
+ * `loadavgmonitor`: Monitor that checks the load average of the system.
  */
 mod common;
 mod commandmonitor;
 mod httpmonitor;
 mod tcpmonitor;
+mod loadavgmonitor;
 
 pub use common::Monitor;
 pub use commandmonitor::CommandMonitor;
 pub use httpmonitor::HttpMonitor;
 pub use tcpmonitor::TcpMonitor;
+pub use loadavgmonitor::LoadAvgMonitor;


### PR DESCRIPTION
Adds a new monitor to the monitoring agent that will monitor the load average of the system. The monitor will check the load average of the system and compare it to the threshold set in the configuration file. If the load average is above the threshold, the monitor will report an error.

Also updates so that the check mthod is now required by by the Monitor. This allows for the removal of multiple methods in the scheduler.

Breaking changes: None

Resolves: #56