### PR TITLE
docs:Issue-69: Update process documentation

### DIFF
--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -219,16 +219,16 @@ pub struct ProcessResponse {
     /// The parent process id.
     #[serde(skip_serializing_if = "Option::is_none", rename = "parentPid")]  
     pub parent_pid: Option<u32>,
-    /// The name of the process.
+    /// Command run by this process. Strings longer than 16 characters (including the terminating null byte) are silently truncated.
     #[serde(skip_serializing_if = "Option::is_none", rename = "name")]      
     pub name: Option<String>,
-    /// The umask of the process.
+    /// Process umask, expressed in octal with a leading zero.
     #[serde(skip_serializing_if = "Option::is_none", rename = "umask")]          
     pub umask: Option<String>,
     /// The state of the process.
     #[serde(skip_serializing_if = "Option::is_none", rename = "processState")]              
     pub state: Option<ProcessStateResponse>,
-    /// The number of threads in the process.
+    /// Number of threads in process containing this thread.
     #[serde(skip_serializing_if = "Option::is_none", rename = "numThreads")]          
     pub threads: Option<u32>,
     /// The groups the process belongs to.
@@ -313,8 +313,6 @@ impl ProcessResponse {
 pub enum ProcessStateResponse {
     /// The process is running.
     Running,
-    /// The process is in an uninterruptible sleep.
-    UninterruptibleSleep,
     /// The process is in an interruptable sleep.
     InterruptableSleep,
     /// The process is stopped.
@@ -323,6 +321,12 @@ pub enum ProcessStateResponse {
     Zombie,
     /// The process is idle.
     Idle,
+    /// The process is in disk sleep.
+    DiskSleep,
+    /// The process is dead.
+    Dead,
+    /// The process is in tracing stop.
+    TracingStop,
     /// The process state is unknown. This probably occurs if the state is not found in the enum.
     Unknown
 }
@@ -340,11 +344,13 @@ impl ProcessStateResponse {
         let Some(state) = state else { return None };
         let new_state = match state {
             ProcessState::Running => ProcessStateResponse::Running,
-            ProcessState::UninterruptibleSleep => ProcessStateResponse::UninterruptibleSleep,
             ProcessState::InterruptableSleep => ProcessStateResponse::InterruptableSleep,
             ProcessState::Stopped => ProcessStateResponse::Stopped,
             ProcessState::Zombie => ProcessStateResponse::Zombie,
             ProcessState::Idle => ProcessStateResponse::Idle,
+            ProcessState::DiskSleep => ProcessStateResponse::DiskSleep,
+            ProcessState::Dead => ProcessStateResponse::Dead,
+            ProcessState::TracingStop => ProcessStateResponse::TracingStop,
             ProcessState::Unknown => ProcessStateResponse::Unknown
         };
         Some(new_state)

--- a/monitoring-agent-lib/src/proc/process.rs
+++ b/monitoring-agent-lib/src/proc/process.rs
@@ -324,18 +324,19 @@ impl ProcsProcess {
      * `state`: The state to get.
      * 
      * Returns the process state.
-     * 
      */
     fn get_state(state: Option<&String>) -> Option<ProcessState> {
         match state {
             Some(state) => {
                 match state.as_str().chars().nth(0) {
                     Some('R') => Some(ProcessState::Running),
-                    Some('D') => Some(ProcessState::UninterruptibleSleep),
+                    Some('D') => Some(ProcessState::DiskSleep),
                     Some('S') => Some(ProcessState::InterruptableSleep),
                     Some('T') => Some(ProcessState::Stopped),
+                    Some('t') => Some(ProcessState::TracingStop),
                     Some('Z') => Some(ProcessState::Zombie),
                     Some('I') => Some(ProcessState::Idle),
+                    Some('X') => Some(ProcessState::Dead),
                     None => None,
                     _ => Some(ProcessState::Unknown)
                 }
@@ -414,8 +415,6 @@ pub enum ProcessState {
     /// The process is running.
     Running,
     /// The process is in an uninterruptible sleep.
-    UninterruptibleSleep,
-    /// The process is in an interruptable sleep.
     InterruptableSleep,
     /// The process is stopped.
     Stopped,
@@ -423,6 +422,12 @@ pub enum ProcessState {
     Zombie,
     /// The process is idle.
     Idle,
+    /// The process is in disk sleep.
+    DiskSleep,
+    /// The process is dead.
+    Dead,
+    /// The process is in tracing stop.
+    TracingStop,
     /// The process state is unknown. This probably occurs if the state is not found in the enum.
     Unknown
 }

--- a/openapi-spec/openapi_spec.yaml.yml
+++ b/openapi-spec/openapi_spec.yaml.yml
@@ -299,7 +299,7 @@ components:
         name:
           type: string
           example: 'ksmserver'
-          description: 'Process name'
+          description: 'Command run by this process. Strings longer than 16 characters (including the terminating null byte) are silently truncated.'
         state:
           type: string
           example: 'S'
@@ -307,17 +307,19 @@ components:
         umask:
           type: string
           example: '0002'
-          description: 'Process umask'
+          description: 'Process umask, expressed in octal with a leading zero.'
         processState:
           type: string
           example: 'InterruptableSleep'
           description: 'Process state. Can be either\n
             Running - The process is running.
-            UninterruptibleSleep - The process is in an uninterruptible sleep.
             InterruptableSleep - The process is in an interruptable sleep.
+            DiskSleep - The process is in a disk sleep.
+            TracingStop - The process is in a tracing stop.
             Stopped - The process is stopped.
             Zombie - The process is a zombie.
             Idle - The process is idle.
+            Dead - The process is dead.
             Unknown - The process state is unknown.'
         numThreads:
           type: number


### PR DESCRIPTION
Updates documentation for the process services and objects. Also updates the process states to include the new states and remove misnamed ones.

Breaking changes: Removed uninterruptableSleep from process states. This is now DiskSleep.

Resolves: #69