### PR TITLE
feat:Issue-73: Create memmonitor

### DIFF
--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -1,6 +1,12 @@
 {
     "database": {
-        "url": "mysql://monitor-agent-rw:[vKsoUcgY0CqHfKU@planescape.forgottendonkey.com:3306/monitor-agent"
+        "host": "planescape.forgottendonkey.com",
+        "port": 3306,
+        "user": "monitor-agent-rw",
+        "password": "[vKsoUcgY0CqHfKU",
+        "database": "monitor-agent",
+        "minConnections": 10,
+        "maxConnections": 100
     },
     "server": {
 	    "ip": "127.0.0.1",
@@ -52,6 +58,16 @@
                 "threshold1min": 2.0,
                 "threshold5min": 2.0,
                 "threshold10min": 2.0,
+                "storeValues": true
+            }
+        },
+        {
+            "name":"Mem",
+            "schedule": "*/5 * * * * *",
+            "details": {
+                "type": "mem",
+                "maxPercentageMemUsed": 2.0,
+                "maxPercentageSwapUsed": 2.0,
                 "storeValues": true
             }
         }

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -59,7 +59,15 @@ pub enum MonitorType {
         threshold_10min: Option<f32>,
         #[serde(rename = "storeValues", default = "default_as_false")]
         store_values: bool,    
-    },    
+    },  
+    Mem {
+        #[serde(skip_serializing_if = "Option::is_none", rename = "maxPercentageMemUsed")]
+        max_percentage_mem: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "maxPercentageSwapUsed")]
+        max_percentage_swap: Option<f64>,        
+        #[serde(rename = "storeValues", default = "default_as_false")]
+        store_values: bool,    
+    },   
 }
 
 /**
@@ -203,8 +211,27 @@ pub struct ServerConfig {
  */
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct DatabaseConfig {
-    /// The database url. Example <mysql://root:password@localhost:3307/db_name>
-    pub url: String,
+    /// The host or ip of the database.
+    #[serde(rename = "host", default = "default_server_ip")]
+    pub host: String,
+    /// The database name
+    #[serde(rename = "database")]
+    pub db_name: String,
+    /// The user.
+    #[serde(rename = "user")]
+    pub user: String,
+    /// The password.
+    #[serde(rename = "password")]
+    pub password: String,
+    /// The port.
+    #[serde(rename = "port")]
+    pub port: u16,
+    /// The minimum connections in pool.
+    #[serde(rename = "minConnections")]
+    pub min_connections: usize,
+    /// The maximum connections in pool.
+    #[serde(rename = "maxConnections")]
+    pub max_connections: usize,    
 }
 
 /**

--- a/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
@@ -1,0 +1,338 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use log::{error, info};
+use monitoring_agent_lib::proc::ProcsMeminfo;
+use tokio_cron_scheduler::Job;
+
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, MariaDbService};
+
+use super::Monitor;
+
+#[derive(Debug, Clone)]
+pub struct MeminfoMonitor {
+    /// The name of the monitor.
+    pub name: String,
+    /// Minimum free percentage memory.
+    pub max_percentage_mem: Option<f64>,
+    /// Minimum free percentage swap memory.
+    pub max_percentage_swap: Option<f64>,
+    /// The status of the monitor.
+    pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,    
+    /// The database service
+    database_service: Arc<Option<MariaDbService>>,
+    /// The database store level.
+    database_store_level: DatabaseStoreLevel,
+    /// The current load average.
+    store_current_meminfo: bool,              
+}
+
+impl MeminfoMonitor {
+
+    /**
+     * Create a new `MeminfoMonitor`.
+     * 
+     * `name`: The name of the monitor.
+     * `max_percentage_mem`: The maximum percentage memory.
+     * `max_percentage_swap`: The maximum percentage swap.
+     * `status`: The status of the monitor.
+     * `database_service`: The database service.
+     * `database_store_level`: The database store level.
+     * `store_current_meminfo`: Store the current load average.
+     * 
+     * Returns: A new `MeminfoMonitor`.
+     * 
+     */
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::similar_names)]    
+    pub fn new(
+        name: &str,
+        max_percentage_mem: Option<f64>,
+        max_percentage_swap: Option<f64>,
+        status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
+        database_service: &Arc<Option<MariaDbService>>,
+        database_store_level: &DatabaseStoreLevel,
+        store_current_meminfo: bool,
+    ) -> MeminfoMonitor {
+
+        let status_lock = status.lock();
+        match status_lock {
+            Ok(mut lock) => {
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+            }
+            Err(err) => {
+                error!("Error creating meminfo monitor: {:?}", err);
+            }
+        }
+
+        MeminfoMonitor {
+            name: name.to_string(),
+            max_percentage_mem,
+            max_percentage_swap,
+            status: status.clone(),
+            database_service: database_service.clone(),
+            database_store_level: database_store_level.clone(),
+            store_current_meminfo,
+        }
+    }
+
+    /**
+     * Check the memory use.
+     * 
+     * `meminfo`: The memory use.
+     * 
+     */
+    #[allow(clippy::similar_names)]         
+    fn check_meminfo(&mut self, meminfo: &ProcsMeminfo) {    
+        let percentage_mem_used = ProcsMeminfo::get_percent_used(meminfo.memfree, meminfo.memtotal);
+        let percentage_swap_used = ProcsMeminfo::get_percent_used(meminfo.swapfree, meminfo.swaptotal);
+
+        let free_percentage_mem_status = MeminfoMonitor::check_meminfo_values(self.max_percentage_mem, percentage_mem_used);
+        let free_percentage_swap_status = MeminfoMonitor::check_meminfo_values(self.max_percentage_swap, percentage_swap_used);
+        
+        if free_percentage_mem_status != Status::Ok || free_percentage_swap_status != Status::Ok{
+            self.set_status(&Status::Error {
+                message: format!(
+                    "Meminfo check failed: mem: {free_percentage_mem_status:?}, swap: {free_percentage_swap_status:?}"
+                ),
+            });
+        } else {
+            self.set_status(&Status::Ok);
+        }
+    }
+
+    /**
+     * Check the load average values.
+     * 
+     * `max`: The max load average.
+     * `current`: The current load average.
+     * 
+     * Returns: The status of the check.
+     * 
+     */
+    fn check_meminfo_values(max: Option<f64>, current: Option<f64>) -> Status {
+        let Some(current) = current else { return Status::Ok };
+        let Some(max) = max else { return Status::Ok };
+            
+        if current > max {
+            return Status::Error {
+                message: format!(
+                    "Memory use {current:0.3}% is more than {max:0.3}%"
+                ),
+            };
+        }
+        Status::Ok       
+    }
+
+    /**
+     * Check and store the currentmeminfo.
+     * 
+     * `meminfo`: The current memory use.
+     * 
+     * 
+     */
+    fn check_store_current_meminfo(&self, meminfo: &ProcsMeminfo) {
+        if self.store_current_meminfo {
+            self.store_current_meminfo(meminfo);
+        }           
+    }
+    
+    /**
+     * Store the current memory use.
+     * 
+     * `meminfo`: The current load average.
+     */
+    fn store_current_meminfo(&self, meminfo: &ProcsMeminfo) {
+        match self.database_service.as_ref() {            
+            Some(database_service) => {
+                match database_service.store_meminfo(meminfo) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        error!("Error storing memory use: {:?}", err);
+                    }
+                }
+            }
+            None => {}
+        }        
+    }
+
+    /**
+     * Get meminfo monitor job.
+     * 
+     * `schedule`: The schedule for the job.
+     * 
+     * Returns: The meminfo monitor job.
+     * 
+     */
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::similar_names)]    
+    pub fn get_meminfo_monitor_job(
+        &mut self,
+        schedule: &str,
+    ) -> Result<Job, ApplicationError> {
+        info!("Creating meminfo monitor: {}", &self.name);
+        let mut meminfo_monitor = self.clone();       
+        let job_result = Job::new(schedule, move |_uuid, _locked| {                
+            meminfo_monitor.check();
+        });        
+        match job_result {
+            Ok(job) => Ok(job),
+            Err(err) => Err(ApplicationError::new(
+                format!("Could not create job: {err}").as_str(),
+            )), 
+        }
+    }    
+
+    /**
+     * Check the monitor.
+     */
+    fn check(&mut self) {
+        let meminfo = ProcsMeminfo::get_meminfo();
+        match meminfo {
+            Ok(meminfo) => {
+                self.check_store_current_meminfo(&meminfo);
+                self.check_meminfo(&meminfo);
+            }
+            Err(err) => {
+                error!("Error getting meminfo: {:?}", err);
+            }
+        }                    
+    }    
+
+}
+
+/**
+ * Implement the `Monitor` trait for `MemoryinfoMonitor`.
+ */
+impl super::Monitor for MeminfoMonitor {
+    /**
+     * Get the name of the monitor.
+     *
+     * Returns: The name of the monitor.
+     */
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /**
+     * Get the status of the monitor.
+     *
+     * Returns: The status of the monitor.
+     */
+    fn get_status(&self) -> Arc<Mutex<HashMap<String, MonitorStatus>>> {
+        self.status.clone()
+    }
+
+    /**
+     * Get the database service.
+     *
+     * Returns: The database service.
+     */
+    fn get_database_service(&self) -> Arc<Option<MariaDbService>> {
+        self.database_service.clone()
+    }
+
+    /**
+     * Get the database store level.
+     *
+     * Returns: The database store level.
+     */
+    fn get_database_store_level(&self) -> DatabaseStoreLevel {
+        self.database_store_level.clone()
+    }
+     
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+    use super::Monitor;
+
+    #[test]
+    fn test_check() {
+        let mut monitor = super::MeminfoMonitor::new(
+            "test",
+            Some(100.0),
+            Some(100.0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            &super::DatabaseStoreLevel::None,
+            false,
+        );
+        monitor.check();
+        let status = monitor.get_status();
+        let status = status.lock().unwrap();
+        assert_eq!(status.get("test").unwrap().status, super::Status::Ok);
+    }
+
+    /**
+     * Test the check_max_meminfo function.
+     * 
+     * Test the following scenarios:
+     * - Memory is lower on all.
+     */
+    #[test]
+    fn test_check_max_meminfo() {
+        // Test success. Memory lower on all
+        let mut monitor = super::MeminfoMonitor::new(
+            "test",
+            Some(80.0),
+            Some(80.0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            &super::DatabaseStoreLevel::None,
+            false,
+        );
+
+        let meminfo = monitoring_agent_lib::proc::ProcsMeminfo {
+            memtotal: Some(32000),
+            memfree: Some(16000),
+            memavailable: Some(16000),
+            swaptotal: Some(10000),
+            swapfree: Some(5000),
+        };
+
+        monitor.check_meminfo(&meminfo);
+
+        let status = monitor.get_status();
+        let status = status.lock().unwrap();
+        assert_eq!(status.get("test").unwrap().status, super::Status::Ok);
+    }
+        
+
+    /**
+     * Test the check_max_meminfo function.
+     * 
+     * Test the following scenarios:
+     * - Memory is lower on all.
+     */
+    #[test]
+    fn test_check_max_meminfo_over() {
+        // Test success. Memory lower on all
+        let mut monitor = super::MeminfoMonitor::new(
+            "test",
+            Some(70.0),
+            Some(15.0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            &super::DatabaseStoreLevel::None,
+            false,
+        );
+
+        let meminfo = monitoring_agent_lib::proc::ProcsMeminfo {
+            memtotal: Some(20000),
+            memfree: Some(5000),
+            memavailable: Some(16000),
+            swaptotal: Some(10000),
+            swapfree: Some(5000),
+        };
+
+        monitor.check_meminfo(&meminfo);
+
+        let status = monitor.get_status();
+        let status = status.lock().unwrap();
+        assert_eq!(status.get("test").unwrap().status, super::Status::Error { message: "Meminfo check failed: mem: Error { message: \"Memory use 75.000% is more than 70.000%\" }, swap: Error { message: \"Memory use 50.000% is more than 15.000%\" }".to_string() });
+    }
+
+
+}

--- a/monitoring-agent-daemon/src/services/monitors/mod.rs
+++ b/monitoring-agent-daemon/src/services/monitors/mod.rs
@@ -12,9 +12,11 @@ mod commandmonitor;
 mod httpmonitor;
 mod tcpmonitor;
 mod loadavgmonitor;
+mod meminfomonitor;
 
 pub use common::Monitor;
 pub use commandmonitor::CommandMonitor;
 pub use httpmonitor::HttpMonitor;
 pub use tcpmonitor::TcpMonitor;
 pub use loadavgmonitor::LoadAvgMonitor;
+pub use meminfomonitor::MeminfoMonitor;

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -5,7 +5,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{configuration::MonitoringConfig, ApplicationError, MonitorStatus};
 use crate::services::MariaDbService;
-use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, TcpMonitor};
+use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, TcpMonitor, MeminfoMonitor};
 
 /**
  * Scheduling Service.
@@ -185,6 +185,12 @@ impl SchedulingService {
             } => {               
                 let mut loadavg_monitor = LoadAvgMonitor::new(&monitor.name, threshold_1min, threshold_5min, threshold_10min, &self.status, &self.database_service.clone(), &monitor.store, store_values);
                 let job = loadavg_monitor.get_loadavg_monitor_job(monitor.schedule.as_str())?;
+                self.add_job(scheduler, job).await
+            },
+            crate::common::MonitorType::Mem {max_percentage_mem, max_percentage_swap, store_values
+            } => {
+                let mut meminfo_monitor = MeminfoMonitor::new(&monitor.name, max_percentage_mem, max_percentage_swap, &self.status, &self.database_service.clone(), &monitor.store, store_values);
+                let job = meminfo_monitor.get_meminfo_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
         }?;   

--- a/monitoring-agent-lib/src/proc/meminfo.rs
+++ b/monitoring-agent-lib/src/proc/meminfo.rs
@@ -105,6 +105,8 @@ impl ProcsMeminfo {
             parts.get("SwapTotal").and_then(|f| u64::from_str(f).ok()),
             parts.get("SwapFree").and_then(|f| u64::from_str(f).ok()),
         ))
+
+
     }
 
     /**
@@ -128,6 +130,23 @@ impl ProcsMeminfo {
             }
         }
     }
+
+
+    /**
+     * Calculate the percentage.
+     * 
+     * `free`: Free memory 
+     * `total`: Total memory 
+     * 
+     * Returns: Percentage or none
+     */
+    #[allow(clippy::cast_precision_loss)]
+    #[must_use]
+    pub fn get_percent_used(free: Option<u64>, total: Option<u64>) -> Option<f64> {
+        let free = free?;
+        let total = total?;   
+        Some(100f64 - ((free as f64 / total as f64) * 100f64))      
+    }    
 }
 
 
@@ -150,6 +169,18 @@ mod test {
         assert_eq!(binding.memavailable, Some(4_491_376));
         assert_eq!(binding.swaptotal, Some(1_998_844));
         assert_eq!(binding.swapfree, Some(13_952));
+    }
+
+    #[test]
+    fn test_get_percent_used() {
+        let result = ProcsMeminfo::get_percent_used(None, None);
+        assert_eq!(result, None);
+        let result = ProcsMeminfo::get_percent_used(Some(32000), None);
+        assert_eq!(result, None);  
+        let result = ProcsMeminfo::get_percent_used(None, Some(32000));
+        assert_eq!(result, None); 
+        let result = ProcsMeminfo::get_percent_used(Some(25000), Some(100000));
+        assert_eq!(result, Some(75f64));                         
     }
 
 }


### PR DESCRIPTION
Implements a memory monitor that reads the /proc/meminfo file and parses the data to get the memory information. Then checks it against the thresholds defined in the configuration file.

Additionally updates the database configuration to improve the database connection handling with connection pooling.

Breaking chnages: None

Resolves: #73