### PR TITLE
feat:Issue-79: Rewrite to use r2d2

### DIFF
--- a/monitoring-agent-daemon/Cargo.toml
+++ b/monitoring-agent-daemon/Cargo.toml
@@ -25,8 +25,8 @@ log = "0.4.22"                                                                  
 actix-web = { version = "4.8.0" }                                                       # For handling http requests.
 chrono = { version = "0.4.38", features = ["serde"]}                                    # For handling time.
 monitoring-agent-lib = { path = "../monitoring-agent-lib" }                             # For reading system information.
-mysql = "25.0.1"                                                                        # For handling mysql connections.
-mysql_common = { version = "0.32.4" }                                                   # For handling mysql connections.
+r2d2 = { version = "0.8.10", features = [   ]}                                          # For handling connection pools.
+r2d2_mysql = "25.0.0"                                                                   # For handling mysql connections. 
 
 [package.metadata.deb]
 maintainer = "Kjetil Fjellheim <kjetil@forgottendonkey.net>"

--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -1,6 +1,6 @@
 {
     "database": {
-        "host": "planescape.forgottendonkey.com",
+        "host": "greyhawk.forgottendonkey.com",
         "port": 3306,
         "user": "monitor-agent-rw",
         "password": "[vKsoUcgY0CqHfKU",

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -228,10 +228,10 @@ pub struct DatabaseConfig {
     pub port: u16,
     /// The minimum connections in pool.
     #[serde(rename = "minConnections")]
-    pub min_connections: usize,
+    pub min_connections: u32,
     /// The maximum connections in pool.
     #[serde(rename = "maxConnections")]
-    pub max_connections: usize,    
+    pub max_connections: u32,    
 }
 
 /**


### PR DESCRIPTION
Rewrite the database service to use r2d2 for handling the connection pool. This will make the database service more robust and easier to add more database types in the future.

Breaking changes: None

Resolves: #79