### PR TITLE
fix:Issue-84:Fix systemd config

### DIFF
--- a/monitoring-agent-daemon/resources/prod/systemd/monitoring-agent.service
+++ b/monitoring-agent-daemon/resources/prod/systemd/monitoring-agent.service
@@ -4,8 +4,8 @@ DefaultDependencies=no
 Before=shutdown.target
 
 [Service]
-ExecStart=/usr/bin/monitoring-agent --daemon
-Type=forking
+ExecStart=/usr/bin/monitoring-agent
+Type=simple
 Restart=on-failure
 TimeoutStartSec=10
 


### PR DESCRIPTION
Fixes systemd job by not running it as a daemon job. This is done by removing --daemon from the command and setting type to simple.

Breaking changes: None

Resolves: #84