### PR TITLE
build:Issue-86: Optimize release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Build binary
-        run: cargo build --release --verbose
+        run: cargo build --release 
+      - name: Strip binary
+        run: strip target/release/monitoring-agent-daemon
       - name: Upload release binary
         uses: actions/upload-release-asset@v1.0.2
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
 [workspace.metadata.spellcheck]
 config = "spellcheck.toml"
 
+
+[profile.release]
+lto = true

--- a/monitoring-agent-daemon/Cargo.toml
+++ b/monitoring-agent-daemon/Cargo.toml
@@ -51,3 +51,6 @@ conf-files = [
     "/etc/monitoring-agent-daemon/logging.yml",
     "/etc/systemd/system/monitoring-agent-daemon.service",
 ]
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Optimize release by enabling lto for release builds. This will optimize the binary size and performance.
Strip the binary to reduce the size of the binary.

Breaking changes: None

Resolves: #86