### PR TITLE
feat: Issue-78:Add postgres support

### DIFF
--- a/monitoring-agent-daemon/Cargo.toml
+++ b/monitoring-agent-daemon/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { version = "0.4.38", features = ["serde"]}                            
 monitoring-agent-lib = { path = "../monitoring-agent-lib" }                             # For reading system information.
 r2d2 = { version = "0.8.10", features = [   ]}                                          # For handling connection pools.
 r2d2_mysql = "25.0.0"                                                                   # For handling mysql connections. 
+r2d2_postgres = "0.18.1"                                                                # For handling postgres connections.
 
 [package.metadata.deb]
 maintainer = "Kjetil Fjellheim <kjetil@forgottendonkey.net>"

--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -1,5 +1,6 @@
 {
     "database": {
+        "type": "Mysql",
         "host": "greyhawk.forgottendonkey.com",
         "port": 3306,
         "user": "monitor-agent-rw",

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -210,10 +210,23 @@ pub struct ServerConfig {
 }
 
 /**
+ * Database type.
+ */
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub enum DatabaseType {
+    Postgres,
+    Mysql,
+    Maria
+}
+
+/**
  * Database configuration.
  */
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct DatabaseConfig {
+    /// The type of database.
+    #[serde(rename = "type")]
+    pub dbtype: DatabaseType,
     /// The host or ip of the database.
     #[serde(rename = "host", default = "default_server_ip")]
     pub host: String,

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -15,7 +15,7 @@ use services::SchedulingService;
 
 use crate::common::ApplicationArguments;
 use crate::api::StateApi;
-use crate::services::{MonitoringService, MariaDbService};
+use crate::services::{MonitoringService, DbService};
 
 /**
  * Application entry point.
@@ -81,7 +81,7 @@ async fn start_application(monitoring_config: &MonitoringConfig, args: &Applicat
      * Initialize database service.
      */
     let database_config = monitoring_config.database.clone();
-    let database_service: Arc<Option<MariaDbService>> = if let Some(database_config) = database_config {
+    let database_service: Arc<Option<DbService>> = if let Some(database_config) = database_config {
         Arc::new(initialize_database(&database_config, &monitoring_config.server))
     } else {
         info!("No database configuration found!");
@@ -145,8 +145,8 @@ async fn start_application(monitoring_config: &MonitoringConfig, args: &Applicat
  * Returns the database service.
  * 
  */
-fn initialize_database(database_config: &DatabaseConfig, server_config: &ServerConfig) -> Option<MariaDbService> {
-    match MariaDbService::new(database_config, &server_config.name) {
+fn initialize_database(database_config: &DatabaseConfig, server_config: &ServerConfig) -> Option<DbService> {
+    match DbService::new(database_config, &server_config.name) {
         Ok(database_service) => {
             info!("Database service initialized!");
             Some(database_service)

--- a/monitoring-agent-daemon/src/services/databaseservice.rs
+++ b/monitoring-agent-daemon/src/services/databaseservice.rs
@@ -8,10 +8,140 @@ use r2d2_mysql::mysql::prelude::Queryable;
 use r2d2_mysql::mysql::OptsBuilder;
 use r2d2_mysql::mysql::TxOpts;
 use r2d2_mysql::MySqlConnectionManager;
+use r2d2_postgres::postgres::tls::NoTls;
+use r2d2_postgres::postgres::Config;
+use r2d2_postgres::PostgresConnectionManager;
+
 
 use crate::common::configuration::DatabaseConfig;
+use crate::common::configuration::DatabaseType;
 use crate::common::Status;
 use crate::common::ApplicationError;
+
+/**
+ * Database Service.
+ * 
+ * This enum represents the database service. It is used to interact with the database.
+ * 
+ */
+#[derive(Debug)]
+pub enum DbService {
+    MariaDb(MariaDbService),
+    PostgresDb(PostgresDbService),
+}
+
+impl DbService {
+
+    /**
+     * Create a new database service.
+     * 
+     * `database_config`: The database configuration.
+     * `server_name`: The server name.
+     * 
+     * Returns: A new database service.
+     * 
+     * Errors:
+     * - If there is an error creating the database service.
+     * 
+     */
+    pub fn new(database_config: &DatabaseConfig, server_name: &str) -> Result<DbService, ApplicationError> {
+        match &database_config.dbtype {
+            DatabaseType::Maria => Ok(DbService::MariaDb(MariaDbService::new(database_config, server_name)?)),
+            DatabaseType::Mysql => Ok(DbService::MariaDb(MariaDbService::new(database_config, server_name)?)),
+            DatabaseType::Postgres => Ok(DbService::PostgresDb(PostgresDbService::new(database_config, server_name)?)),
+        }
+    }
+
+    /**
+     * Insert a monitor status into the database.
+     * 
+     * `name`: The name of the monitor.
+     * `status`: The status of the monitor.
+     * 
+     * Returns: Ok if the status was inserted successfully.
+     * 
+     * Errors:
+     * - If there is an error inserting the status.
+     * - If there is an error starting a transaction.
+     * - If there is an error committing the transaction.
+     * 
+     */
+    pub fn insert_monitor_status(&self, name: &str, status: &Status) -> Result<(), ApplicationError> {
+        match self {
+            DbService::MariaDb(service) => service.insert_monitor_status(name, status),
+            DbService::PostgresDb(service) => service.insert_monitor_status(name, status),
+        }
+    }
+
+    /**
+     * Store the load average in the database.
+     * 
+     * `loadavg`: The load average to store.
+     * 
+     * Returns: Ok if the load average was stored successfully.
+     * 
+     * Errors:
+     * - If there is an error storing the load average.
+     * - If there is an error starting a transaction.
+     * 
+     */
+    pub fn store_loadavg(&self, loadavg: &ProcsLoadavg) -> Result<(), ApplicationError> {
+        match self {
+            DbService::MariaDb(service) => service.store_loadavg(loadavg),
+            DbService::PostgresDb(service) => service.store_loadavg(loadavg),
+        }
+    }
+
+    /**
+     * Store the meminfo in the database.
+     * 
+     * `meminfo`: The meminfo to store.
+     * 
+     * Returns: Ok if the meminfo was stored successfully.
+     * 
+     * Errors:
+     * - If there is an error storing the meminfo.
+     * - If there is an error starting a transaction.
+     * 
+     */
+    pub fn store_meminfo(&self, meminfo: &ProcsMeminfo) -> Result<(), ApplicationError> {
+        match self {
+            DbService::MariaDb(service) => service.store_meminfo(meminfo),
+            DbService::PostgresDb(service) => service.store_meminfo(meminfo),
+        }
+    }
+
+    /**
+     * Get the database representation of the status.
+     * 
+     * `status`: The status to get the database representation of.
+     * 
+     * Returns: The database representation.
+     * 
+     */
+    fn get_status_db_repr(status: &Status) -> String {
+        match &status {
+            Status::Error { message: _ } => "ERROR".to_string(),
+            Status::Ok => "OK".to_string(),
+            Status::Unknown => "UNKNOWN".to_string(),
+        }
+    }
+
+    /**
+     * Get the message from the status.
+     *
+     * `status`: The status to get the message from.
+     *
+     * Returns: The message.
+     *
+     */
+    fn get_message(status: &Status) -> Option<String> {
+        match status {
+            Status::Error { message } => Some(message.clone()),
+            _ => None,
+        }
+    }    
+}
 
 /**
  * `MariaDB` Service.
@@ -84,43 +214,13 @@ impl MariaDbService {
         tx.exec_drop("INSERT INTO monitor_status (server_name, monitor_name, status, log_time, message) VALUES (:server_name,:name, :status, now(3), :message)", params! {
             "server_name" => self.server_name.to_string(),
             "name" => &name,
-            "status" => MariaDbService::get_status_db_repr(status),
-            "message" => MariaDbService::get_message(status),
+            "status" => DbService::get_status_db_repr(status),
+            "message" => DbService::get_message(status),
         }).map_err(|err| ApplicationError::new(&err.to_string()))?;
         tx.commit().map_err(|err| ApplicationError::new(&err.to_string()))?;
         Ok(())
     }
 
-    /**
-     * Get the database representation of the status.
-     * 
-     * `status`: The status to get the database representation of.
-     * 
-     * Returns: The database representation.
-     * 
-     */
-    fn get_status_db_repr(status: &Status) -> String {
-        match &status {
-            Status::Error { message: _ } => "ERROR".to_string(),
-            Status::Ok => "OK".to_string(),
-            Status::Unknown => "UNKNOWN".to_string(),
-        }
-    }
-
-    /**
-     * Get the message from the status.
-     *
-     * `status`: The status to get the message from.
-     *
-     * Returns: The message.
-     *
-     */
-    fn get_message(status: &Status) -> Option<String> {
-        match status {
-            Status::Error { message } => Some(message.clone()),
-            _ => None,
-        }
-    }
     /**
      * Store the load average in the database.
      * 
@@ -174,4 +274,128 @@ impl MariaDbService {
         Ok(())
     }
 
+}
+
+
+#[derive(Debug)]
+pub struct PostgresDbService {
+    /// The database connection pool.
+    pool: Pool<PostgresConnectionManager<NoTls>>,
+    /// Server name
+    server_name: String
+}
+
+impl PostgresDbService {
+    
+    /**
+     * Create a new `Postgres` service.
+     * 
+     * `database_config`: The database configuration.
+     * 
+     * Returns: A new `Postgres` service.
+     * 
+     * Errors:
+     * - If there is an error creating the pool.
+     */
+    pub fn new(database_config: &DatabaseConfig, server_name: &str) -> Result<PostgresDbService, ApplicationError> {
+
+        let manager = r2d2_postgres::PostgresConnectionManager::new(Config::new()
+            .host(&database_config.host)
+            .dbname(&database_config.db_name)
+            .user(&database_config.user)
+            .password(&database_config.password)
+            .port(database_config.port).clone(), NoTls);
+
+        let pool = r2d2::Pool::builder()
+            .max_size(database_config.max_connections)
+            .min_idle(Some(database_config.min_connections))
+            .build(manager)
+            .map_err(|err| ApplicationError::new(&err.to_string()))?;
+        /*
+         * Verify connection
+         */
+        Ok(PostgresDbService {
+            pool,
+            server_name: server_name.to_string()
+        })
+    }
+
+    /**
+     * Insert a monitor status into the database.
+     * 
+     * `name`: The name of the monitor.
+     * `status`: The status of the monitor.
+     * `message`: The message associated with the status.
+     * 
+     * Returns: Ok if the status was inserted successfully.
+     * 
+     * Errors:
+     * - If there is an error inserting the status.
+     * - If there is an error starting a transaction.
+     * - If there is an error committing the transaction.
+     * 
+     */
+    pub fn insert_monitor_status(&self, name: &str, status: &Status) -> Result<(), ApplicationError> {
+        let mut conn = self.pool.get().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        let mut tx = conn.transaction().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.execute("INSERT INTO monitor_status (server_name, monitor_name, status, log_time, message) VALUES ($1, $2, $3, now(), $4)", &[
+            &self.server_name,
+            &name,
+            &DbService::get_status_db_repr(status),
+            &DbService::get_message(status),
+        ]).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.commit().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        Ok(())
+    }
+
+    /**
+     * Store the load average in the database.
+     * 
+     * `loadavg`: The load average to store.
+     * 
+     * Returns: Ok if the load average was stored successfully.
+     * 
+     * Errors:
+     * - If there is an error storing the load average.
+     * - If there is an error starting a transaction.
+     */
+    pub fn store_loadavg(&self, loadavg: &ProcsLoadavg) -> Result<(), ApplicationError> {
+        let mut conn = self.pool.get().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        let mut tx = conn.transaction().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.execute("INSERT INTO loadavg (server_name, loadavg1min, loadavg5min, loadavg10min, num_processes, num_running_processes, log_time) VALUES ($1, $2, $3, $4, $5, $6, now())", &[
+            &self.server_name,
+            &loadavg.loadavg1min,
+            &loadavg.loadavg5min,
+            &loadavg.loadavg10min,
+            &loadavg.total_number_of_processes,
+            &loadavg.current_running_processes,
+        ]).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.commit().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        Ok(())
+    }
+
+    /**
+     * Store the meminfo in the database.
+     * 
+     * `meminfo`: The meminfo to store.
+     * 
+     * Returns: Ok if the meminfo was stored successfully.
+     * 
+     * Errors:
+     * - If there is an error storing the meminfo.
+     * - If there is an error starting a transaction.
+     */
+    pub fn store_meminfo(&self, meminfo: &ProcsMeminfo) -> Result<(), ApplicationError> {
+        let mut conn = self.pool.get().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        let mut tx = conn.transaction().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.execute("INSERT INTO meminfo (server_name, freemem, mem_percent_used, freeswap, swap_percent_used, log_time) VALUES ($1, $2, $3, $4, $5, now())", &[
+            &self.server_name,
+            &meminfo.memfree.map(|x| i64::try_from(x).ok()),
+            &ProcsMeminfo::get_percent_used(meminfo.memfree, meminfo.memtotal),
+            &meminfo.swapfree.map(|x| i64::try_from(x).ok()),
+            &ProcsMeminfo::get_percent_used(meminfo.swapfree, meminfo.swaptotal),
+        ]).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.commit().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        Ok(())
+    }
 }

--- a/monitoring-agent-daemon/src/services/mod.rs
+++ b/monitoring-agent-daemon/src/services/mod.rs
@@ -13,5 +13,5 @@ mod databaseservice;
 
 pub use monitoringservice::MonitoringService;
 pub use schedulingservice::SchedulingService;
-pub use databaseservice::MariaDbService;
+pub use databaseservice::DbService;
 

--- a/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
@@ -6,7 +6,7 @@ use std::{
 use log::{debug, error, info};
 use tokio_cron_scheduler::Job;
 
-use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::{monitors::Monitor, MariaDbService}};
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::{monitors::Monitor, DbService}};
 
 /**
  * Command Monitor.
@@ -27,7 +27,7 @@ pub struct CommandMonitor {
     /// The current status of the monitor.
     pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
-    database_service: Arc<Option<MariaDbService>>,   
+    database_service: Arc<Option<DbService>>,   
     /// The database store level.
     database_store_level: DatabaseStoreLevel, 
 }
@@ -53,7 +53,7 @@ impl CommandMonitor {
         args: Option<Vec<String>>,
         expected: Option<String>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
-        database_service: &Arc<Option<MariaDbService>>,
+        database_service: &Arc<Option<DbService>>,
         database_store_level: &DatabaseStoreLevel
     ) -> CommandMonitor {
         let status_lock = status.lock();
@@ -216,7 +216,7 @@ impl super::Monitor for CommandMonitor {
      *
      * Returns: The database service.
      */
-    fn get_database_service(&self) -> Arc<Option<MariaDbService>> {
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
         self.database_service.clone()
     }
  

--- a/monitoring-agent-daemon/src/services/monitors/common.rs
+++ b/monitoring-agent-daemon/src/services/monitors/common.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::{Arc, Mutex}};
 
 use log::{debug, error};
 
-use crate::{common::{configuration::DatabaseStoreLevel, MonitorStatus, Status}, services::MariaDbService};
+use crate::{common::{configuration::DatabaseStoreLevel, MonitorStatus, Status}, services::DbService};
 
 pub trait Monitor {
     
@@ -25,7 +25,7 @@ pub trait Monitor {
      *
      * Returns: The database service.
      */
-    fn get_database_service(&self) -> Arc<Option<MariaDbService>>;
+    fn get_database_service(&self) -> Arc<Option<DbService>>;
 
     /**
      * Get the database store level.

--- a/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
@@ -16,7 +16,7 @@ use crate::common::ApplicationError;
 use crate::common::{MonitorStatus, Status};
 use crate::common::HttpMethod;
 use crate::services::monitors::Monitor;
-use crate::services::MariaDbService;
+use crate::services::DbService;
 
 /**
  * HTTP Monitor.
@@ -47,7 +47,7 @@ pub struct HttpMonitor {
     /// The status of the monitor.
     pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
-    database_service: Arc<Option<MariaDbService>>,
+    database_service: Arc<Option<DbService>>,
     /// The database store level.
     database_store_level: DatabaseStoreLevel,         
 }
@@ -87,7 +87,7 @@ impl HttpMonitor {
         identity: Option<String>,
         identity_password: Option<String>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
-        database_service: &Arc<Option<MariaDbService>>,
+        database_service: &Arc<Option<DbService>>,
         database_store_level: &DatabaseStoreLevel,
     ) -> Result<HttpMonitor, ApplicationError> {
         debug!("Creating HTTP monitor: {}", &name);
@@ -456,7 +456,7 @@ impl super::Monitor for HttpMonitor {
      *
      * Returns: The database service.
      */
-    fn get_database_service(&self) -> Arc<Option<MariaDbService>> {
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
         self.database_service.clone()
     }
 

--- a/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
@@ -4,7 +4,7 @@ use log::{error, info};
 use monitoring_agent_lib::proc::ProcsLoadavg;
 use tokio_cron_scheduler::Job;
 
-use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, MariaDbService};
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, DbService};
 
 use super::Monitor;
 
@@ -21,7 +21,7 @@ pub struct LoadAvgMonitor {
     /// The status of the monitor.
     pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
-    database_service: Arc<Option<MariaDbService>>,
+    database_service: Arc<Option<DbService>>,
     /// The database store level.
     database_store_level: DatabaseStoreLevel,
     /// The current load average.
@@ -53,7 +53,7 @@ impl LoadAvgMonitor {
         loadavg5min_max: Option<f32>,
         loadavg10min_max: Option<f32>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
-        database_service: &Arc<Option<MariaDbService>>,
+        database_service: &Arc<Option<DbService>>,
         database_store_level: &DatabaseStoreLevel,
         store_current_loadavg: bool,
     ) -> LoadAvgMonitor {
@@ -239,7 +239,7 @@ impl super::Monitor for LoadAvgMonitor {
      *
      * Returns: The database service.
      */
-    fn get_database_service(&self) -> Arc<Option<MariaDbService>> {
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
         self.database_service.clone()
     }
 

--- a/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
@@ -4,7 +4,7 @@ use log::{error, info};
 use monitoring_agent_lib::proc::ProcsMeminfo;
 use tokio_cron_scheduler::Job;
 
-use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, MariaDbService};
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, DbService};
 
 use super::Monitor;
 
@@ -19,7 +19,7 @@ pub struct MeminfoMonitor {
     /// The status of the monitor.
     pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,    
     /// The database service
-    database_service: Arc<Option<MariaDbService>>,
+    database_service: Arc<Option<DbService>>,
     /// The database store level.
     database_store_level: DatabaseStoreLevel,
     /// The current load average.
@@ -49,7 +49,7 @@ impl MeminfoMonitor {
         max_percentage_mem: Option<f64>,
         max_percentage_swap: Option<f64>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
-        database_service: &Arc<Option<MariaDbService>>,
+        database_service: &Arc<Option<DbService>>,
         database_store_level: &DatabaseStoreLevel,
         store_current_meminfo: bool,
     ) -> MeminfoMonitor {
@@ -227,7 +227,7 @@ impl super::Monitor for MeminfoMonitor {
      *
      * Returns: The database service.
      */
-    fn get_database_service(&self) -> Arc<Option<MariaDbService>> {
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
         self.database_service.clone()
     }
 

--- a/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 
 use crate::common::configuration::DatabaseStoreLevel;
 use crate::common::{ApplicationError, MonitorStatus, Status};
-use crate::services::MariaDbService;
+use crate::services::DbService;
 
 use super::Monitor;
 
@@ -34,7 +34,7 @@ pub struct TcpMonitor {
     /// The status of the monitor.
     pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
-    database_service: Arc<Option<MariaDbService>>,
+    database_service: Arc<Option<DbService>>,
     /// The database store level.
     database_store_level: DatabaseStoreLevel,
 }
@@ -54,7 +54,7 @@ impl TcpMonitor {
         port: u16,
         name: &str,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
-        database_service: &Arc<Option<MariaDbService>>,
+        database_service: &Arc<Option<DbService>>,
         database_store_level: &DatabaseStoreLevel,
     ) -> TcpMonitor {
         debug!("Creating TCP monitor: {}", &name);
@@ -181,7 +181,7 @@ impl super::Monitor for TcpMonitor {
      *
      * Returns: The database service.
      */
-    fn get_database_service(&self) -> Arc<Option<MariaDbService>> {
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
         self.database_service.clone()
     }
 

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -4,7 +4,7 @@ use log::info;
 use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{configuration::MonitoringConfig, ApplicationError, MonitorStatus};
-use crate::services::MariaDbService;
+use crate::services::DbService;
 use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, TcpMonitor, MeminfoMonitor};
 
 /**
@@ -24,7 +24,7 @@ pub struct SchedulingService {
     /// The status of the monitors.
     status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
-    database_service: Arc<Option<MariaDbService>>,
+    database_service: Arc<Option<DbService>>,
 }
 
 impl SchedulingService {
@@ -34,7 +34,7 @@ impl SchedulingService {
      *
      * result: The result of creating the scheduling service.
      */
-    pub fn new(monitoring_config: &MonitoringConfig, status: &Arc<Mutex<HashMap<String, MonitorStatus>>>, database_service: &Arc<Option<MariaDbService>>) -> SchedulingService {
+    pub fn new(monitoring_config: &MonitoringConfig, status: &Arc<Mutex<HashMap<String, MonitorStatus>>>, database_service: &Arc<Option<DbService>>) -> SchedulingService {
         SchedulingService {
             scheduler: None,
             monitoring_config: monitoring_config.clone(),


### PR DESCRIPTION
Adds postgres support to the monitoring agent daemon. This includes storing the data in a postgres database and adding the necessary configuration options to the configuration file.

Breaking changes: type of database field in the configuration file is now required. No default value is provided.

Resolves: #78