### PR TITLE
feat:Issue-91: Fix tokio issue with postgres connections

### DIFF
--- a/monitoring-agent-daemon/Cargo.toml
+++ b/monitoring-agent-daemon/Cargo.toml
@@ -28,6 +28,9 @@ monitoring-agent-lib = { path = "../monitoring-agent-lib" }                     
 r2d2 = { version = "0.8.10", features = [   ]}                                          # For handling connection pools.
 r2d2_mysql = "25.0.0"                                                                   # For handling mysql connections. 
 r2d2_postgres = "0.18.1"                                                                # For handling postgres connections.
+bb8 = "0.8.5"                                                                           # For handling connection pools.
+bb8-postgres = "0.8.0"                                                                  # For handling postgres connections.
+rust_decimal = { version = "1.35.0", features = ["db-postgres"] }
 
 [package.metadata.deb]
 maintainer = "Kjetil Fjellheim <kjetil@forgottendonkey.net>"

--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -1,8 +1,8 @@
 {
     "database": {
-        "type": "Mysql",
+        "type": "Postgres",
         "host": "greyhawk.forgottendonkey.com",
-        "port": 3306,
+        "port": 5432,
         "user": "monitor-agent-rw",
         "password": "[vKsoUcgY0CqHfKU",
         "database": "monitor-agent",

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -82,7 +82,7 @@ async fn start_application(monitoring_config: &MonitoringConfig, args: &Applicat
      */
     let database_config = monitoring_config.database.clone();
     let database_service: Arc<Option<DbService>> = if let Some(database_config) = database_config {
-        Arc::new(initialize_database(&database_config, &monitoring_config.server))
+        Arc::new(initialize_database(&database_config, &monitoring_config.server).await)
     } else {
         info!("No database configuration found!");
         Arc::new(None)
@@ -145,8 +145,8 @@ async fn start_application(monitoring_config: &MonitoringConfig, args: &Applicat
  * Returns the database service.
  * 
  */
-fn initialize_database(database_config: &DatabaseConfig, server_config: &ServerConfig) -> Option<DbService> {
-    match DbService::new(database_config, &server_config.name) {
+async fn initialize_database(database_config: &DatabaseConfig, server_config: &ServerConfig) -> Option<DbService> {
+    match DbService::new(database_config, &server_config.name).await {
         Ok(database_service) => {
             info!("Database service initialized!");
             Some(database_service)

--- a/monitoring-agent-daemon/src/services/monitors/common.rs
+++ b/monitoring-agent-daemon/src/services/monitors/common.rs
@@ -40,8 +40,8 @@ pub trait Monitor {
      * `new_status`: The new status.
      *
      */
-    fn set_status(&mut self, new_status: &Status) {
-        self.insert_monitor_status(new_status);
+    async fn set_status(&mut self, new_status: &Status) {
+        self.insert_monitor_status(new_status).await;
         let status = self.get_status();
         match status.lock() {
             Ok(mut monitor_lock) => {
@@ -67,7 +67,7 @@ pub trait Monitor {
      * status: The status to insert.
      *
      */
-    fn insert_monitor_status(&mut self, status: &Status) {
+    async fn insert_monitor_status(&mut self, status: &Status) {
         match self.get_database_store_level() {
             DatabaseStoreLevel::None => {
                 return;
@@ -89,7 +89,7 @@ pub trait Monitor {
                 match database_service.insert_monitor_status(
                     self.get_name(),
                     &status.clone(),
-                ) {
+                ).await {
                     Ok(()) => {}
                     Err(err) => {
                         error!("Error inserting monitor status: {:?}", err);


### PR DESCRIPTION
Mysql/Mariadb driver does not use tokio, but postgres does so when postgres queries it does a block_on. This causes the application to crash as it blocks the main thread. To fix this make the database service async. This will require a major rewrite as it will affect all the code. To make the postgres connections use async we cannot use r2d2, but must use bb8 connectionpool.

Breaking changes: None

Resolves: #91