### PR TITLE
feat:Issue-5:New systemctl monitor

### DIFF
--- a/monitoring-agent-daemon/resources/test/systemctl_test.out
+++ b/monitoring-agent-daemon/resources/test/systemctl_test.out
@@ -1,0 +1,579 @@
+  UNIT                                                                                                                   LOAD      ACTIVE   SUB       DESCRIPTION
+  proc-sys-fs-binfmt_misc.automount                                                                                      loaded    active   running   Arbitrary Executable File Formats File System Automount Point
+  dev-disk-by\x2ddiskseq-13.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/13
+  dev-disk-by\x2ddiskseq-14.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/14
+  dev-disk-by\x2ddiskseq-15.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/15
+  dev-disk-by\x2ddiskseq-16.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/16
+  dev-disk-by\x2ddiskseq-17.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/17
+  dev-disk-by\x2ddiskseq-18.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/18
+  dev-disk-by\x2ddiskseq-19.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/19
+  dev-disk-by\x2ddiskseq-20.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/20
+  dev-disk-by\x2ddiskseq-22.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/22
+  dev-disk-by\x2ddiskseq-24.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/24
+  dev-disk-by\x2ddiskseq-26.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/26
+  dev-disk-by\x2ddiskseq-28.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/28
+  dev-disk-by\x2ddiskseq-30.device                                                                                       loaded    active   plugged   /dev/disk/by-diskseq/30
+  dev-disk-by\x2ddiskseq-9.device                                                                                        loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1
+  dev-disk-by\x2ddiskseq-9\x2dpart1.device                                                                               loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2ddiskseq-9\x2dpart2.device                                                                               loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-disk-by\x2ddiskseq-9\x2dpart3.device                                                                               loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-disk-by\x2did-dm\x2dname\x2dnvme0n1p3_crypt.device                                                                 loaded    active   plugged   /dev/disk/by-id/dm-name-nvme0n1p3_crypt
+  dev-disk-by\x2did-dm\x2dname\x2dvgkubuntu\x2droot.device                                                               loaded    active   plugged   /dev/disk/by-id/dm-name-vgkubuntu-root
+  dev-disk-by\x2did-dm\x2dname\x2dvgkubuntu\x2dswap_1.device                                                             loaded    active   plugged   /dev/disk/by-id/dm-name-vgkubuntu-swap_1
+  dev-disk-by\x2did-dm\x2duuid\x2dCRYPT\x2dLUKS2\x2d4837f34feeaa4b0695f7a364d63cdf8d\x2dnvme0n1p3_crypt.device           loaded    active   plugged   /dev/disk/by-id/dm-uuid-CRYPT-LUKS2-4837f34feeaa4b0695f7a364d63cdf8d-nvme0n1p3_crypt
+  dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dRoD89g5mYULmxHElrSKDCmJut5r4Ov35tRNLpfM3RF32wqL3m3M5K458cDSBHwzw.device         loaded    active   plugged   /dev/disk/by-id/dm-uuid-LVM-RoD89g5mYULmxHElrSKDCmJut5r4Ov35tRNLpfM3RF32wqL3m3M5K458cDSBHwzw
+  dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dRoD89g5mYULmxHElrSKDCmJut5r4Ov35vDcLToeD938D3UJpzFfxTdUj75HLq2Wf.device         loaded    active   plugged   /dev/disk/by-id/dm-uuid-LVM-RoD89g5mYULmxHElrSKDCmJut5r4Ov35vDcLToeD938D3UJpzFfxTdUj75HLq2Wf
+  dev-disk-by\x2did-lvm\x2dpv\x2duuid\x2dXuoVh4\x2dy9pu\x2deL5C\x2dEgEl\x2d3KJg\x2dJalz\x2d92Rbvi.device                 loaded    active   plugged   /dev/disk/by-id/lvm-pv-uuid-XuoVh4-y9pu-eL5C-EgEl-3KJg-Jalz-92Rbvi
+  dev-disk-by\x2did-nvme\x2deui.002538b83104dd26.device                                                                  loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1
+  dev-disk-by\x2did-nvme\x2deui.002538b83104dd26\x2dpart1.device                                                         loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2did-nvme\x2deui.002538b83104dd26\x2dpart2.device                                                         loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-disk-by\x2did-nvme\x2deui.002538b83104dd26\x2dpart3.device                                                         loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227.device                                          loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227\x2dpart1.device                                 loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227\x2dpart2.device                                 loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227\x2dpart3.device                                 loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227_1.device                                        loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227_1\x2dpart1.device                               loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227_1\x2dpart2.device                               loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-disk-by\x2did-nvme\x2dSAMSUNG_MZVL21T0HDLU\x2d00BH1_S6Z3NE0W827227_1\x2dpart3.device                               loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30015514.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30015514
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30015522.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30015522
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30015556.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30015556
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30015638.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30015638
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30015692.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30015692
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30016187.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30016187
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30016492.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30016492
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30021429.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30021429
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30024850.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30024850
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30024851.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30024851
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30024853.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30024853
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30024854.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30024854
+  dev-disk-by\x2dloop\x2dinode-252:1\x2d30024855.device                                                                  loaded    active   plugged   /dev/disk/by-loop-inode/252:1-30024855
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fbare_5.snap.device                       loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fbare_5.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fcanonical\x2dlivepatch_282.snap.device   loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fcanonical-livepatch_282.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fcore22_1380.snap.device                  loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fcore22_1380.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fcore22_864.snap.device                   loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fcore22_864.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2ffirefox_4630.snap.device                 loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2ffirefox_4630.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2ffirefox_4650.snap.device                 loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2ffirefox_4650.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fgnome\x2d42\x2d2204_141.snap.device      loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fgnome-42-2204_141.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fgnome\x2d42\x2d2204_176.snap.device      loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fgnome-42-2204_176.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fgtk\x2dcommon\x2dthemes_1535.snap.device loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fgtk-common-themes_1535.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fsnapd_20092.snap.device                  loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fsnapd_20092.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fsnapd_21759.snap.device                  loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fsnapd_21759.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fthunderbird_490.snap.device              loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fthunderbird_490.snap
+  dev-disk-by\x2dloop\x2dref-\x5cx2fvar\x5cx2flib\x5cx2fsnapd\x5cx2fsnaps\x5cx2fthunderbird_497.snap.device              loaded    active   plugged   /dev/disk/by-loop-ref/\x2fvar\x2flib\x2fsnapd\x2fsnaps\x2fthunderbird_497.snap
+  dev-disk-by\x2dpartlabel-EFI\x5cx20System\x5cx20Partition.device                                                       loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2dpartuuid-a254c187\x2dcc45\x2d4952\x2db5a0\x2dbd8d80f45a8a.device                                        loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-disk-by\x2dpartuuid-a72e5f92\x2d2dcb\x2d4b44\x2db803\x2d17f9be1022d0.device                                        loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-disk-by\x2dpartuuid-fe079942\x2dda3b\x2d45ba\x2daa69\x2de27f98d89a75.device                                        loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2dpath-pci\x2d0000:04:00.0\x2dnvme\x2d1.device                                                            loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1
+  dev-disk-by\x2dpath-pci\x2d0000:04:00.0\x2dnvme\x2d1\x2dpart1.device                                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2dpath-pci\x2d0000:04:00.0\x2dnvme\x2d1\x2dpart2.device                                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-disk-by\x2dpath-pci\x2d0000:04:00.0\x2dnvme\x2d1\x2dpart3.device                                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-disk-by\x2duuid-16923efb\x2d5644\x2d4d72\x2d9c66\x2df17b6ccf995f.device                                            loaded    active   plugged   /dev/disk/by-uuid/16923efb-5644-4d72-9c66-f17b6ccf995f
+  dev-disk-by\x2duuid-4837f34f\x2deeaa\x2d4b06\x2d95f7\x2da364d63cdf8d.device                                            loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-disk-by\x2duuid-A123\x2dF910.device                                                                                loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-disk-by\x2duuid-ae77b0f7\x2d5356\x2d4798\x2da1b9\x2d11562a6a95ad.device                                            loaded    active   plugged   /dev/disk/by-uuid/ae77b0f7-5356-4798-a1b9-11562a6a95ad
+  dev-disk-by\x2duuid-b4eecb14\x2d2be9\x2d4f11\x2d8003\x2dfaa099d4fb6c.device                                            loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-dm\x2d0.device                                                                                                     loaded    active   plugged   /dev/dm-0
+  dev-dm\x2d1.device                                                                                                     loaded    active   plugged   /dev/dm-1
+  dev-dm\x2d2.device                                                                                                     loaded    active   plugged   /dev/dm-2
+  dev-loop0.device                                                                                                       loaded    active   plugged   /dev/loop0
+  dev-loop1.device                                                                                                       loaded    active   plugged   /dev/loop1
+  dev-loop10.device                                                                                                      loaded    active   plugged   /dev/loop10
+  dev-loop11.device                                                                                                      loaded    active   plugged   /dev/loop11
+  dev-loop12.device                                                                                                      loaded    active   plugged   /dev/loop12
+  dev-loop2.device                                                                                                       loaded    active   plugged   /dev/loop2
+  dev-loop3.device                                                                                                       loaded    active   plugged   /dev/loop3
+  dev-loop4.device                                                                                                       loaded    active   plugged   /dev/loop4
+  dev-loop5.device                                                                                                       loaded    active   plugged   /dev/loop5
+  dev-loop6.device                                                                                                       loaded    active   plugged   /dev/loop6
+  dev-loop7.device                                                                                                       loaded    active   plugged   /dev/loop7
+  dev-loop8.device                                                                                                       loaded    active   plugged   /dev/loop8
+  dev-loop9.device                                                                                                       loaded    active   plugged   /dev/loop9
+  dev-mapper-nvme0n1p3_crypt.device                                                                                      loaded    active   plugged   /dev/mapper/nvme0n1p3_crypt
+  dev-mapper-vgkubuntu\x2droot.device                                                                                    loaded    active   plugged   /dev/mapper/vgkubuntu-root
+  dev-mapper-vgkubuntu\x2dswap_1.device                                                                                  loaded    active   plugged   /dev/mapper/vgkubuntu-swap_1
+  dev-nvme0n1.device                                                                                                     loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1
+  dev-nvme0n1p1.device                                                                                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  dev-nvme0n1p2.device                                                                                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  dev-nvme0n1p3.device                                                                                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  dev-rfkill.device                                                                                                      loaded    active   plugged   /dev/rfkill
+  dev-snd-by\x2dpath-pci\x2d0000:01:00.1.device                                                                          loaded    active   plugged   /dev/snd/by-path/pci-0000:01:00.1
+  dev-snd-by\x2dpath-pci\x2d0000:05:00.1.device                                                                          loaded    active   plugged   /dev/snd/by-path/pci-0000:05:00.1
+  dev-snd-by\x2dpath-pci\x2d0000:05:00.5\x2dplatform\x2dacp_ps_mach.0.device                                             loaded    active   plugged   /dev/snd/by-path/pci-0000:05:00.5-platform-acp_ps_mach.0
+  dev-snd-by\x2dpath-pci\x2d0000:05:00.6.device                                                                          loaded    active   plugged   /dev/snd/by-path/pci-0000:05:00.6
+  dev-snd-controlC0.device                                                                                               loaded    active   plugged   /dev/snd/controlC0
+  dev-snd-controlC1.device                                                                                               loaded    active   plugged   /dev/snd/controlC1
+  dev-snd-controlC2.device                                                                                               loaded    active   plugged   /dev/snd/controlC2
+  dev-snd-controlC3.device                                                                                               loaded    active   plugged   /dev/snd/controlC3
+  dev-tpm0.device                                                                                                        loaded    active   plugged   /dev/tpm0
+  dev-tpmrm0.device                                                                                                      loaded    active   plugged   /dev/tpmrm0
+  dev-ttyprintk.device                                                                                                   loaded    active   plugged   /dev/ttyprintk
+  dev-ttyS0.device                                                                                                       loaded    active   plugged   /dev/ttyS0
+  dev-ttyS1.device                                                                                                       loaded    active   plugged   /dev/ttyS1
+  dev-ttyS10.device                                                                                                      loaded    active   plugged   /dev/ttyS10
+  dev-ttyS11.device                                                                                                      loaded    active   plugged   /dev/ttyS11
+  dev-ttyS12.device                                                                                                      loaded    active   plugged   /dev/ttyS12
+  dev-ttyS13.device                                                                                                      loaded    active   plugged   /dev/ttyS13
+  dev-ttyS14.device                                                                                                      loaded    active   plugged   /dev/ttyS14
+  dev-ttyS15.device                                                                                                      loaded    active   plugged   /dev/ttyS15
+  dev-ttyS16.device                                                                                                      loaded    active   plugged   /dev/ttyS16
+  dev-ttyS17.device                                                                                                      loaded    active   plugged   /dev/ttyS17
+  dev-ttyS18.device                                                                                                      loaded    active   plugged   /dev/ttyS18
+  dev-ttyS19.device                                                                                                      loaded    active   plugged   /dev/ttyS19
+  dev-ttyS2.device                                                                                                       loaded    active   plugged   /dev/ttyS2
+  dev-ttyS20.device                                                                                                      loaded    active   plugged   /dev/ttyS20
+  dev-ttyS21.device                                                                                                      loaded    active   plugged   /dev/ttyS21
+  dev-ttyS22.device                                                                                                      loaded    active   plugged   /dev/ttyS22
+  dev-ttyS23.device                                                                                                      loaded    active   plugged   /dev/ttyS23
+  dev-ttyS24.device                                                                                                      loaded    active   plugged   /dev/ttyS24
+  dev-ttyS25.device                                                                                                      loaded    active   plugged   /dev/ttyS25
+  dev-ttyS26.device                                                                                                      loaded    active   plugged   /dev/ttyS26
+  dev-ttyS27.device                                                                                                      loaded    active   plugged   /dev/ttyS27
+  dev-ttyS28.device                                                                                                      loaded    active   plugged   /dev/ttyS28
+  dev-ttyS29.device                                                                                                      loaded    active   plugged   /dev/ttyS29
+  dev-ttyS3.device                                                                                                       loaded    active   plugged   /dev/ttyS3
+  dev-ttyS30.device                                                                                                      loaded    active   plugged   /dev/ttyS30
+  dev-ttyS31.device                                                                                                      loaded    active   plugged   /dev/ttyS31
+  dev-ttyS4.device                                                                                                       loaded    active   plugged   /dev/ttyS4
+  dev-ttyS5.device                                                                                                       loaded    active   plugged   /dev/ttyS5
+  dev-ttyS6.device                                                                                                       loaded    active   plugged   /dev/ttyS6
+  dev-ttyS7.device                                                                                                       loaded    active   plugged   /dev/ttyS7
+  dev-ttyS8.device                                                                                                       loaded    active   plugged   /dev/ttyS8
+  dev-ttyS9.device                                                                                                       loaded    active   plugged   /dev/ttyS9
+  dev-vgkubuntu-root.device                                                                                              loaded    active   plugged   /dev/vgkubuntu/root
+  dev-vgkubuntu-swap_1.device                                                                                            loaded    active   plugged   /dev/vgkubuntu/swap_1
+  sys-devices-LNXSYSTM:00-LNXSYBUS:00-MSFT0101:00-tpm-tpm0.device                                                        loaded    active   plugged   /sys/devices/LNXSYSTM:00/LNXSYBUS:00/MSFT0101:00/tpm/tpm0
+  sys-devices-LNXSYSTM:00-LNXSYBUS:00-MSFT0101:00-tpmrm-tpmrm0.device                                                    loaded    active   plugged   /sys/devices/LNXSYSTM:00/LNXSYBUS:00/MSFT0101:00/tpmrm/tpmrm0
+  sys-devices-pci0000:00-0000:00:01.1-0000:01:00.1-sound-card0-controlC0.device                                          loaded    active   plugged   /sys/devices/pci0000:00/0000:00:01.1/0000:01:00.1/sound/card0/controlC0
+  sys-devices-pci0000:00-0000:00:02.2-0000:02:00.0-net-wlo1.device                                                       loaded    active   plugged   /sys/devices/pci0000:00/0000:00:02.2/0000:02:00.0/net/wlo1
+  sys-devices-pci0000:00-0000:00:02.3-0000:03:00.0-net-eno1.device                                                       loaded    active   plugged   RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller
+  sys-devices-pci0000:00-0000:00:02.4-0000:04:00.0-nvme-nvme0-nvme0n1-nvme0n1p1.device                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 EFI\x20System\x20Partition
+  sys-devices-pci0000:00-0000:00:02.4-0000:04:00.0-nvme-nvme0-nvme0n1-nvme0n1p2.device                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 2
+  sys-devices-pci0000:00-0000:00:02.4-0000:04:00.0-nvme-nvme0-nvme0n1-nvme0n1p3.device                                   loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1 3
+  sys-devices-pci0000:00-0000:00:02.4-0000:04:00.0-nvme-nvme0-nvme0n1.device                                             loaded    active   plugged   SAMSUNG MZVL21T0HDLU-00BH1
+  sys-devices-pci0000:00-0000:00:08.1-0000:05:00.0-drm-card1-card1\x2deDP\x2d1-amdgpu_bl1.device                         loaded    active   plugged   /sys/devices/pci0000:00/0000:00:08.1/0000:05:00.0/drm/card1/card1-eDP-1/amdgpu_bl1
+  sys-devices-pci0000:00-0000:00:08.1-0000:05:00.1-sound-card1-controlC1.device                                          loaded    active   plugged   /sys/devices/pci0000:00/0000:00:08.1/0000:05:00.1/sound/card1/controlC1
+  sys-devices-pci0000:00-0000:00:08.1-0000:05:00.3-usb1-1\x2d5-1\x2d5:1.0-bluetooth-hci0.device                          loaded    active   plugged   /sys/devices/pci0000:00/0000:00:08.1/0000:05:00.3/usb1/1-5/1-5:1.0/bluetooth/hci0
+  sys-devices-pci0000:00-0000:00:08.1-0000:05:00.5-acp_ps_mach.0-sound-card3-controlC3.device                            loaded    active   plugged   /sys/devices/pci0000:00/0000:00:08.1/0000:05:00.5/acp_ps_mach.0/sound/card3/controlC3
+  sys-devices-pci0000:00-0000:00:08.1-0000:05:00.6-sound-card2-controlC2.device                                          loaded    active   plugged   /sys/devices/pci0000:00/0000:00:08.1/0000:05:00.6/sound/card2/controlC2
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.0-tty-ttyS0.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.0/tty/ttyS0
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.1-tty-ttyS1.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.1/tty/ttyS1
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.10-tty-ttyS10.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.10/tty/ttyS10
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.11-tty-ttyS11.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.11/tty/ttyS11
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.12-tty-ttyS12.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.12/tty/ttyS12
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.13-tty-ttyS13.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.13/tty/ttyS13
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.14-tty-ttyS14.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.14/tty/ttyS14
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.15-tty-ttyS15.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.15/tty/ttyS15
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.16-tty-ttyS16.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.16/tty/ttyS16
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.17-tty-ttyS17.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.17/tty/ttyS17
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.18-tty-ttyS18.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.18/tty/ttyS18
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.19-tty-ttyS19.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.19/tty/ttyS19
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.2-tty-ttyS2.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.2/tty/ttyS2
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.20-tty-ttyS20.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.20/tty/ttyS20
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.21-tty-ttyS21.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.21/tty/ttyS21
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.22-tty-ttyS22.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.22/tty/ttyS22
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.23-tty-ttyS23.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.23/tty/ttyS23
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.24-tty-ttyS24.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.24/tty/ttyS24
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.25-tty-ttyS25.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.25/tty/ttyS25
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.26-tty-ttyS26.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.26/tty/ttyS26
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.27-tty-ttyS27.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.27/tty/ttyS27
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.28-tty-ttyS28.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.28/tty/ttyS28
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.29-tty-ttyS29.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.29/tty/ttyS29
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.3-tty-ttyS3.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.3/tty/ttyS3
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.30-tty-ttyS30.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.30/tty/ttyS30
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.31-tty-ttyS31.device                                         loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.31/tty/ttyS31
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.4-tty-ttyS4.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.4/tty/ttyS4
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.5-tty-ttyS5.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.5/tty/ttyS5
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.6-tty-ttyS6.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.6/tty/ttyS6
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.7-tty-ttyS7.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.7/tty/ttyS7
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.8-tty-ttyS8.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.8/tty/ttyS8
+  sys-devices-platform-serial8250-serial8250:0-serial8250:0.9-tty-ttyS9.device                                           loaded    active   plugged   /sys/devices/platform/serial8250/serial8250:0/serial8250:0.9/tty/ttyS9
+  sys-devices-virtual-block-dm\x2d0.device                                                                               loaded    active   plugged   /sys/devices/virtual/block/dm-0
+  sys-devices-virtual-block-dm\x2d1.device                                                                               loaded    active   plugged   /sys/devices/virtual/block/dm-1
+  sys-devices-virtual-block-dm\x2d2.device                                                                               loaded    active   plugged   /sys/devices/virtual/block/dm-2
+  sys-devices-virtual-block-loop0.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop0
+  sys-devices-virtual-block-loop1.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop1
+  sys-devices-virtual-block-loop10.device                                                                                loaded    active   plugged   /sys/devices/virtual/block/loop10
+  sys-devices-virtual-block-loop11.device                                                                                loaded    active   plugged   /sys/devices/virtual/block/loop11
+  sys-devices-virtual-block-loop12.device                                                                                loaded    active   plugged   /sys/devices/virtual/block/loop12
+  sys-devices-virtual-block-loop2.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop2
+  sys-devices-virtual-block-loop3.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop3
+  sys-devices-virtual-block-loop4.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop4
+  sys-devices-virtual-block-loop5.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop5
+  sys-devices-virtual-block-loop6.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop6
+  sys-devices-virtual-block-loop7.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop7
+  sys-devices-virtual-block-loop8.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop8
+  sys-devices-virtual-block-loop9.device                                                                                 loaded    active   plugged   /sys/devices/virtual/block/loop9
+  sys-devices-virtual-misc-rfkill.device                                                                                 loaded    active   plugged   /sys/devices/virtual/misc/rfkill
+  sys-devices-virtual-tty-ttyprintk.device                                                                               loaded    active   plugged   /sys/devices/virtual/tty/ttyprintk
+  sys-module-configfs.device                                                                                             loaded    active   plugged   /sys/module/configfs
+  sys-module-fuse.device                                                                                                 loaded    active   plugged   /sys/module/fuse
+  sys-subsystem-bluetooth-devices-hci0.device                                                                            loaded    active   plugged   /sys/subsystem/bluetooth/devices/hci0
+  sys-subsystem-net-devices-eno1.device                                                                                  loaded    active   plugged   RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller
+  sys-subsystem-net-devices-wlo1.device                                                                                  loaded    active   plugged   /sys/subsystem/net/devices/wlo1
+  -.mount                                                                                                                loaded    active   mounted   Root Mount
+  boot-efi.mount                                                                                                         loaded    active   mounted   /boot/efi
+  boot.mount                                                                                                             loaded    active   mounted   /boot
+  dev-hugepages.mount                                                                                                    loaded    active   mounted   Huge Pages File System
+  dev-mqueue.mount                                                                                                       loaded    active   mounted   POSIX Message Queue File System
+● home.mount                                                                                                             not-found inactive dead      home.mount
+  proc-sys-fs-binfmt_misc.mount                                                                                          loaded    active   mounted   Arbitrary Executable File Formats File System
+● run-credentials-systemd\x2dresolved.service.mount                                                                      not-found inactive dead      run-credentials-systemd\x2dresolved.service.mount
+● run-credentials-systemd\x2dsysctl.service.mount                                                                        not-found inactive dead      run-credentials-systemd\x2dsysctl.service.mount
+● run-credentials-systemd\x2dsysusers.service.mount                                                                      not-found inactive dead      run-credentials-systemd\x2dsysusers.service.mount
+● run-credentials-systemd\x2dtmpfiles\x2dclean.service.mount                                                             not-found inactive dead      run-credentials-systemd\x2dtmpfiles\x2dclean.service.mount
+● run-credentials-systemd\x2dtmpfiles\x2dsetup.service.mount                                                             not-found inactive dead      run-credentials-systemd\x2dtmpfiles\x2dsetup.service.mount
+● run-credentials-systemd\x2dtmpfiles\x2dsetup\x2ddev.service.mount                                                      not-found inactive dead      run-credentials-systemd\x2dtmpfiles\x2dsetup\x2ddev.service.mount
+● run-credentials-systemd\x2dtmpfiles\x2dsetup\x2ddev\x2dearly.service.mount                                             not-found inactive dead      run-credentials-systemd\x2dtmpfiles\x2dsetup\x2ddev\x2dearly.service.mount
+  run-snapd-ns-canonical\x2dlivepatch.mnt.mount                                                                          loaded    active   mounted   /run/snapd/ns/canonical-livepatch.mnt
+  run-snapd-ns.mount                                                                                                     loaded    active   mounted   /run/snapd/ns
+  run-user-1000-doc.mount                                                                                                loaded    active   mounted   /run/user/1000/doc
+  run-user-1000.mount                                                                                                    loaded    active   mounted   /run/user/1000
+  snap-bare-5.mount                                                                                                      loaded    active   mounted   Mount unit for bare, revision 5
+  snap-canonical\x2dlivepatch-282.mount                                                                                  loaded    active   mounted   Mount unit for canonical-livepatch, revision 282
+  snap-core22-1380.mount                                                                                                 loaded    active   mounted   Mount unit for core22, revision 1380
+  snap-core22-864.mount                                                                                                  loaded    active   mounted   Mount unit for core22, revision 864
+  snap-firefox-4630.mount                                                                                                loaded    active   mounted   Mount unit for firefox, revision 4630
+  snap-firefox-4650.mount                                                                                                loaded    active   mounted   Mount unit for firefox, revision 4650
+  snap-gnome\x2d42\x2d2204-141.mount                                                                                     loaded    active   mounted   Mount unit for gnome-42-2204, revision 141
+  snap-gnome\x2d42\x2d2204-176.mount                                                                                     loaded    active   mounted   Mount unit for gnome-42-2204, revision 176
+  snap-gtk\x2dcommon\x2dthemes-1535.mount                                                                                loaded    active   mounted   Mount unit for gtk-common-themes, revision 1535
+  snap-snapd-20092.mount                                                                                                 loaded    active   mounted   Mount unit for snapd, revision 20092
+  snap-snapd-21759.mount                                                                                                 loaded    active   mounted   Mount unit for snapd, revision 21759
+  snap-thunderbird-490.mount                                                                                             loaded    active   mounted   Mount unit for thunderbird, revision 490
+  snap-thunderbird-497.mount                                                                                             loaded    active   mounted   Mount unit for thunderbird, revision 497
+  sys-fs-fuse-connections.mount                                                                                          loaded    active   mounted   FUSE Control File System
+  sys-kernel-config.mount                                                                                                loaded    active   mounted   Kernel Configuration File System
+  sys-kernel-debug.mount                                                                                                 loaded    active   mounted   Kernel Debug File System
+  sys-kernel-tracing.mount                                                                                               loaded    active   mounted   Kernel Trace File System
+● tmp.mount                                                                                                              not-found inactive dead      tmp.mount
+  var-snap-firefox-common-host\x2dhunspell.mount                                                                         loaded    active   mounted   Mount unit for firefox, revision 3216 via mount-control
+  apport-autoreport.path                                                                                                 loaded    inactive dead      Process error reports when automatic reporting is enabled (file watch)
+  cups.path                                                                                                              loaded    active   running   CUPS Scheduler
+  systemd-ask-password-console.path                                                                                      loaded    inactive dead      Dispatch Password Requests to Console Directory Watch
+  systemd-ask-password-plymouth.path                                                                                     loaded    active   waiting   Forward Password Requests to Plymouth Directory Watch
+  systemd-ask-password-wall.path                                                                                         loaded    active   waiting   Forward Password Requests to Wall Directory Watch
+  tpm-udev.path                                                                                                          loaded    inactive dead      Handle dynamically added tpm devices
+  whoopsie.path                                                                                                          loaded    active   waiting   Start whoopsie on modification of the /var/crash directory
+  init.scope                                                                                                             loaded    active   running   System and Service Manager
+  session-3.scope                                                                                                        loaded    active   running   Session 3 of User kjetil
+  accounts-daemon.service                                                                                                loaded    active   running   Accounts Service
+  alsa-restore.service                                                                                                   loaded    active   exited    Save/Restore Sound Card State
+  alsa-state.service                                                                                                     loaded    inactive dead      Manage Sound Card State (restore and store)
+  anacron.service                                                                                                        loaded    inactive dead      Run anacron jobs
+  apache2.service                                                                                                        loaded    active   running   The Apache HTTP Server
+  apparmor.service                                                                                                       loaded    active   exited    Load AppArmor profiles
+  apport-autoreport.service                                                                                              loaded    inactive dead      Process error reports when automatic reporting is enabled
+  apport.service                                                                                                         loaded    active   exited    automatic crash report generation
+  apt-daily-upgrade.service                                                                                              loaded    inactive dead      Daily apt upgrade and clean activities
+  apt-daily.service                                                                                                      loaded    inactive dead      Daily apt download activities
+● auditd.service                                                                                                         not-found inactive dead      auditd.service
+● auto-cpufreq.service                                                                                                   not-found inactive dead      auto-cpufreq.service
+  avahi-daemon.service                                                                                                   loaded    active   running   Avahi mDNS/DNS-SD Stack
+  blk-availability.service                                                                                               loaded    active   exited    Availability of block devices
+  bluetooth.service                                                                                                      loaded    active   running   Bluetooth service
+● connman.service                                                                                                        not-found inactive dead      connman.service
+● console-screen.service                                                                                                 not-found inactive dead      console-screen.service
+  console-setup.service                                                                                                  loaded    active   exited    Set console font and keymap
+  cron.service                                                                                                           loaded    active   running   Regular background program processing daemon
+  cups-browsed.service                                                                                                   loaded    active   running   Make remote CUPS printers available locally
+  cups.service                                                                                                           loaded    active   running   CUPS Scheduler
+  dbus.service                                                                                                           loaded    active   running   D-Bus System Message Bus
+  dm-event.service                                                                                                       loaded    inactive dead      Device-mapper event daemon
+  dmesg.service                                                                                                          loaded    inactive dead      Save initial kernel messages after boot
+  dpkg-db-backup.service                                                                                                 loaded    inactive dead      Daily dpkg database backup service
+  e2scrub_all.service                                                                                                    loaded    inactive dead      Online ext4 Metadata Check for All Filesystems
+  e2scrub_reap.service                                                                                                   loaded    inactive dead      Remove Stale Online ext4 Metadata Check Snapshots
+  emergency.service                                                                                                      loaded    inactive dead      Emergency Shell
+● fcoe.service                                                                                                           not-found inactive dead      fcoe.service
+  fstrim.service                                                                                                         loaded    inactive dead      Discard unused blocks on filesystems from /etc/fstab
+  fwupd-refresh.service                                                                                                  loaded    inactive dead      Refresh fwupd metadata and update motd
+  fwupd.service                                                                                                          loaded    active   running   Firmware update daemon
+  getty-static.service                                                                                                   loaded    inactive dead      getty on tty2-tty6 if dbus and logind are not available
+  getty@tty1.service                                                                                                     loaded    inactive dead      Getty on tty1
+  gpu-manager.service                                                                                                    loaded    inactive dead      Detect the available GPUs and deal with any system changes
+  grub-common.service                                                                                                    loaded    inactive dead      Record successful boot for GRUB
+  grub-initrd-fallback.service                                                                                           loaded    inactive dead      GRUB failed boot detection
+  initrd-cleanup.service                                                                                                 loaded    inactive dead      Cleaning Up and Shutting Down Daemons
+  initrd-parse-etc.service                                                                                               loaded    inactive dead      Mountpoints Configured in the Real Root
+  initrd-switch-root.service                                                                                             loaded    inactive dead      Switch Root
+  initrd-udevadm-cleanup-db.service                                                                                      loaded    inactive dead      Cleanup udev Database
+● iscsi-shutdown.service                                                                                                 not-found inactive dead      iscsi-shutdown.service
+● iscsi.service                                                                                                          not-found inactive dead      iscsi.service
+● iscsid.service                                                                                                         not-found inactive dead      iscsid.service
+● kbd.service                                                                                                            not-found inactive dead      kbd.service
+  kerneloops.service                                                                                                     loaded    active   running   Tool to automatically collect and submit kernel crash signatures
+  keyboard-setup.service                                                                                                 loaded    active   exited    Set the console keyboard layout
+  kmod-static-nodes.service                                                                                              loaded    active   exited    Create List of Static Device Nodes
+  ldconfig.service                                                                                                       loaded    inactive dead      Rebuild Dynamic Linker Cache
+  logrotate.service                                                                                                      loaded    inactive dead      Rotate log files
+  lvm2-lvmpolld.service                                                                                                  loaded    inactive dead      LVM2 poll daemon
+  lvm2-monitor.service                                                                                                   loaded    active   exited    Monitoring of LVM2 mirrors, snapshots etc. using dmeventd or progress polling
+  man-db.service                                                                                                         loaded    inactive dead      Daily man-db regeneration
+  memcached.service                                                                                                      loaded    active   running   memcached daemon
+  ModemManager.service                                                                                                   loaded    active   running   Modem Manager
+  modprobe@configfs.service                                                                                              loaded    inactive dead      Load Kernel Module configfs
+  modprobe@dm_mod.service                                                                                                loaded    inactive dead      Load Kernel Module dm_mod
+  modprobe@drm.service                                                                                                   loaded    inactive dead      Load Kernel Module drm
+  modprobe@efi_pstore.service                                                                                            loaded    inactive dead      Load Kernel Module efi_pstore
+  modprobe@fuse.service                                                                                                  loaded    inactive dead      Load Kernel Module fuse
+  modprobe@loop.service                                                                                                  loaded    inactive dead      Load Kernel Module loop
+  monitoring_agent.service                                                                                               loaded    inactive dead      Monitoring agent
+  motd-news.service                                                                                                      loaded    inactive dead      Message of the Day
+  netplan-ovs-cleanup.service                                                                                            loaded    inactive dead      OpenVSwitch configuration for cleanup
+  networkd-dispatcher.service                                                                                            loaded    inactive dead      Dispatcher daemon for systemd-networkd
+  NetworkManager-wait-online.service                                                                                     loaded    active   exited    Network Manager Wait Online
+  NetworkManager.service                                                                                                 loaded    active   running   Network Manager
+● nmbd.service                                                                                                           loaded    failed   failed    Samba NMB Daemon
+● nslcd.service                                                                                                          not-found inactive dead      nslcd.service
+● oem-config.service                                                                                                     not-found inactive dead      oem-config.service
+  openvpn.service                                                                                                        loaded    active   exited    OpenVPN service
+● ovsdb-server.service                                                                                                   not-found inactive dead      ovsdb-server.service
+  phpsessionclean.service                                                                                                loaded    inactive dead      Clean php session files
+  plocate-updatedb.service                                                                                               loaded    inactive dead      Update the plocate database
+  plymouth-quit-wait.service                                                                                             loaded    inactive dead      Hold until boot process finishes up
+  plymouth-quit.service                                                                                                  loaded    active   exited    Terminate Plymouth Boot Screen
+  plymouth-read-write.service                                                                                            loaded    active   exited    Tell Plymouth To Write Out Runtime Data
+  plymouth-start.service                                                                                                 loaded    active   exited    Show Plymouth Boot Screen
+  plymouth-switch-root.service                                                                                           loaded    inactive dead      Plymouth switch root service
+  polkit.service                                                                                                         loaded    active   running   Authorization Manager
+  power-profiles-daemon.service                                                                                          loaded    active   running   Power Profiles daemon
+● rbdmap.service                                                                                                         not-found inactive dead      rbdmap.service
+  rc-local.service                                                                                                       loaded    inactive dead      /etc/rc.local Compatibility
+  rescue.service                                                                                                         loaded    inactive dead      Rescue Shell
+  rsyslog.service                                                                                                        loaded    active   running   System Logging Service
+  rtkit-daemon.service                                                                                                   loaded    active   running   RealtimeKit Scheduling Policy Service
+  samba-ad-dc.service                                                                                                    loaded    inactive dead      Samba AD Daemon
+  sddm.service                                                                                                           loaded    active   running   Simple Desktop Display Manager
+  secureboot-db.service                                                                                                  loaded    inactive dead      Secure Boot updates for DB and DBX
+  setvtrgb.service                                                                                                       loaded    active   exited    Set console scheme
+  smartmontools.service                                                                                                  loaded    active   running   Self Monitoring and Reporting Technology (SMART) Daemon
+  smbd.service                                                                                                           loaded    active   running   Samba SMB Daemon
+  snap.canonical-livepatch.canonical-livepatchd.service                                                                  loaded    active   running   Service for snap application canonical-livepatch.canonical-livepatchd
+● snapd.aa-prompt-listener.service                                                                                       not-found inactive dead      snapd.aa-prompt-listener.service
+  snapd.apparmor.service                                                                                                 loaded    active   exited    Load AppArmor profiles managed internally by snapd
+  snapd.autoimport.service                                                                                               loaded    inactive dead      Auto import assertions from block devices
+  snapd.core-fixup.service                                                                                               loaded    inactive dead      Automatically repair incorrect owner/permissions on core devices
+  snapd.failure.service                                                                                                  loaded    inactive dead      Failure handling of the snapd snap
+  snapd.recovery-chooser-trigger.service                                                                                 loaded    inactive dead      Wait for the Ubuntu Core chooser trigger
+  snapd.seeded.service                                                                                                   loaded    active   exited    Wait until snapd is fully seeded
+  snapd.service                                                                                                          loaded    active   running   Snap Daemon
+  snapd.snap-repair.service                                                                                              loaded    inactive dead      Automatically fetch and run repair assertions
+  snapd.system-shutdown.service                                                                                          loaded    inactive dead      Ubuntu core (all-snaps) system shutdown helper setup service
+  ssl-cert.service                                                                                                       loaded    inactive dead      Generate snakeoil SSL keypair
+  switcheroo-control.service                                                                                             loaded    active   running   Switcheroo Control Proxy service
+● system76-power.service                                                                                                 not-found inactive dead      system76-power.service
+  systemd-ask-password-console.service                                                                                   loaded    inactive dead      Dispatch Password Requests to Console
+  systemd-ask-password-plymouth.service                                                                                  loaded    inactive dead      Forward Password Requests to Plymouth
+  systemd-ask-password-wall.service                                                                                      loaded    inactive dead      Forward Password Requests to Wall
+  systemd-backlight@backlight:amdgpu_bl1.service                                                                         loaded    active   exited    Load/Save Screen Backlight Brightness of backlight:amdgpu_bl1
+  systemd-battery-check.service                                                                                          loaded    inactive dead      Check battery level during early boot
+  systemd-binfmt.service                                                                                                 loaded    active   exited    Set Up Additional Binary Formats
+  systemd-bsod.service                                                                                                   loaded    inactive dead      Displays emergency message in full screen.
+  systemd-cryptsetup@nvme0n1p3_crypt.service                                                                             loaded    active   exited    Cryptography Setup for nvme0n1p3_crypt
+  systemd-firstboot.service                                                                                              loaded    inactive dead      First Boot Wizard
+  systemd-fsck-root.service                                                                                              loaded    inactive dead      File System Check on Root Device
+  systemd-fsck@dev-disk-by\x2duuid-A123\x2dF910.service                                                                  loaded    active   exited    File System Check on /dev/disk/by-uuid/A123-F910
+  systemd-fsck@dev-disk-by\x2duuid-b4eecb14\x2d2be9\x2d4f11\x2d8003\x2dfaa099d4fb6c.service                              loaded    active   exited    File System Check on /dev/disk/by-uuid/b4eecb14-2be9-4f11-8003-faa099d4fb6c
+  systemd-fsckd.service                                                                                                  loaded    inactive dead      File System Check Daemon to report status
+  systemd-hibernate-resume.service                                                                                       loaded    inactive dead      Resume from hibernation
+  systemd-hwdb-update.service                                                                                            loaded    inactive dead      Rebuild Hardware Database
+  systemd-hybrid-sleep.service                                                                                           loaded    inactive dead      System Hybrid Suspend+Hibernate
+  systemd-initctl.service                                                                                                loaded    inactive dead      initctl Compatibility Daemon
+  systemd-journal-catalog-update.service                                                                                 loaded    inactive dead      Rebuild Journal Catalog
+  systemd-journal-flush.service                                                                                          loaded    active   exited    Flush Journal to Persistent Storage
+  systemd-journald.service                                                                                               loaded    active   running   Journal Service
+  systemd-logind.service                                                                                                 loaded    active   running   User Login Management
+  systemd-machine-id-commit.service                                                                                      loaded    inactive dead      Commit a transient machine-id on disk
+  systemd-modules-load.service                                                                                           loaded    active   exited    Load Kernel Modules
+  systemd-networkd.service                                                                                               loaded    inactive dead      Network Configuration
+● systemd-oomd.service                                                                                                   not-found inactive dead      systemd-oomd.service
+  systemd-pcrmachine.service                                                                                             loaded    inactive dead      TPM2 PCR Machine ID Measurement
+  systemd-pcrphase-initrd.service                                                                                        loaded    inactive dead      TPM2 PCR Barrier (initrd)
+  systemd-pcrphase-sysinit.service                                                                                       loaded    inactive dead      TPM2 PCR Barrier (Initialization)
+  systemd-pcrphase.service                                                                                               loaded    inactive dead      TPM2 PCR Barrier (User)
+  systemd-pstore.service                                                                                                 loaded    inactive dead      Platform Persistent Storage Archival
+  systemd-quotacheck.service                                                                                             loaded    inactive dead      File System Quota Check
+  systemd-random-seed.service                                                                                            loaded    active   exited    Load/Save OS Random Seed
+  systemd-remount-fs.service                                                                                             loaded    active   exited    Remount Root and Kernel File Systems
+  systemd-repart.service                                                                                                 loaded    inactive dead      Repartition Root Disk
+  systemd-resolved.service                                                                                               loaded    active   running   Network Name Resolution
+  systemd-rfkill.service                                                                                                 loaded    inactive dead      Load/Save RF Kill Switch Status
+  systemd-soft-reboot.service                                                                                            loaded    inactive dead      Reboot System Userspace
+  systemd-suspend-then-hibernate.service                                                                                 loaded    inactive dead      System Suspend then Hibernate
+  systemd-sysctl.service                                                                                                 loaded    active   exited    Apply Kernel Variables
+  systemd-sysext.service                                                                                                 loaded    inactive dead      Merge System Extension Images into /usr/ and /opt/
+  systemd-sysusers.service                                                                                               loaded    inactive dead      Create System Users
+  systemd-timesyncd.service                                                                                              loaded    active   running   Network Time Synchronization
+  systemd-tmpfiles-clean.service                                                                                         loaded    inactive dead      Cleanup of Temporary Directories
+  systemd-tmpfiles-setup-dev-early.service                                                                               loaded    active   exited    Create Static Device Nodes in /dev gracefully
+  systemd-tmpfiles-setup-dev.service                                                                                     loaded    active   exited    Create Static Device Nodes in /dev
+  systemd-tmpfiles-setup.service                                                                                         loaded    active   exited    Create Volatile Files and Directories
+  systemd-tpm2-setup-early.service                                                                                       loaded    inactive dead      TPM2 SRK Setup (Early)
+  systemd-tpm2-setup.service                                                                                             loaded    inactive dead      TPM2 SRK Setup
+  systemd-udev-settle.service                                                                                            loaded    active   exited    Wait for udev To Complete Device Initialization
+  systemd-udev-trigger.service                                                                                           loaded    active   exited    Coldplug All udev Devices
+  systemd-udevd.service                                                                                                  loaded    active   running   Rule-based Manager for Device Events and Files
+  systemd-update-done.service                                                                                            loaded    inactive dead      Update is Completed
+  systemd-update-utmp-runlevel.service                                                                                   loaded    inactive dead      Record Runlevel Change in UTMP
+  systemd-update-utmp.service                                                                                            loaded    active   exited    Record System Boot/Shutdown in UTMP
+  systemd-user-sessions.service                                                                                          loaded    active   exited    Permit User Sessions
+● systemd-vconsole-setup.service                                                                                         not-found inactive dead      systemd-vconsole-setup.service
+  thermald.service                                                                                                       loaded    inactive dead      Thermal Daemon Service
+  tinyproxy.service                                                                                                      loaded    active   running   Tinyproxy lightweight HTTP Proxy
+● tlp.service                                                                                                            not-found inactive dead      tlp.service
+  tpm-udev.service                                                                                                       loaded    inactive dead      Handle dynamically added tpm devices
+● tuned.service                                                                                                          not-found inactive dead      tuned.service
+● ua-auto-attach.service                                                                                                 not-found inactive dead      ua-auto-attach.service
+  ua-reboot-cmds.service                                                                                                 loaded    inactive dead      Ubuntu Pro reboot cmds
+  ua-timer.service                                                                                                       loaded    inactive dead      Ubuntu Pro Timer for running repeated jobs
+● ubuntu-advantage-cloud-id-shim.service                                                                                 not-found inactive dead      ubuntu-advantage-cloud-id-shim.service
+  ubuntu-advantage.service                                                                                               loaded    inactive dead      Ubuntu Pro Background Auto Attach
+  udisks2.service                                                                                                        loaded    active   running   Disk Manager
+  ufw.service                                                                                                            loaded    active   exited    Uncomplicated firewall
+  unattended-upgrades.service                                                                                            loaded    active   running   Unattended Upgrades Shutdown
+  update-notifier-download.service                                                                                       loaded    inactive dead      Download data for packages that failed at package install time
+  update-notifier-motd.service                                                                                           loaded    inactive dead      Check to see whether there is a new version of Ubuntu available
+  upower.service                                                                                                         loaded    active   running   Daemon for power management
+  user-runtime-dir@1000.service                                                                                          loaded    active   exited    User Runtime Directory /run/user/1000
+  user@1000.service                                                                                                      loaded    active   running   User Manager for UID 1000
+  uuidd.service                                                                                                          loaded    inactive dead      Daemon for generating UUIDs
+  whoopsie.service                                                                                                       loaded    inactive dead      crash report submission
+● winbind.service                                                                                                        not-found inactive dead      winbind.service
+  wpa_supplicant.service                                                                                                 loaded    active   running   WPA supplicant
+● zfs-mount.service                                                                                                      not-found inactive dead      zfs-mount.service
+  -.slice                                                                                                                loaded    active   active    Root Slice
+  system-getty.slice                                                                                                     loaded    active   active    Slice /system/getty
+  system-modprobe.slice                                                                                                  loaded    active   active    Slice /system/modprobe
+  system-systemd\x2dbacklight.slice                                                                                      loaded    active   active    Slice /system/systemd-backlight
+  system-systemd\x2dcryptsetup.slice                                                                                     loaded    active   active    Encrypted Volume Units Service Slice
+  system-systemd\x2dfsck.slice                                                                                           loaded    active   active    Slice /system/systemd-fsck
+  system.slice                                                                                                           loaded    active   active    System Slice
+  user-1000.slice                                                                                                        loaded    active   active    User Slice of UID 1000
+  user.slice                                                                                                             loaded    active   active    User and Session Slice
+  apport-forward.socket                                                                                                  loaded    inactive dead      Unix socket for apport crash forwarding
+  avahi-daemon.socket                                                                                                    loaded    active   running   Avahi mDNS/DNS-SD Stack Activation Socket
+  cups.socket                                                                                                            loaded    active   running   CUPS Scheduler
+  dbus.socket                                                                                                            loaded    active   running   D-Bus System Message Bus Socket
+  dm-event.socket                                                                                                        loaded    active   listening Device-mapper event daemon FIFOs
+  lvm2-lvmpolld.socket                                                                                                   loaded    active   listening LVM2 poll daemon socket
+  snapd.socket                                                                                                           loaded    active   running   Socket activation for snappy daemon
+  syslog.socket                                                                                                          loaded    active   running   Syslog Socket
+  systemd-fsckd.socket                                                                                                   loaded    active   listening fsck to fsckd communication Socket
+  systemd-initctl.socket                                                                                                 loaded    active   listening initctl Compatibility Named Pipe
+  systemd-journald-audit.socket                                                                                          loaded    inactive dead      Journal Audit Socket
+  systemd-journald-dev-log.socket                                                                                        loaded    active   running   Journal Socket (/dev/log)
+  systemd-journald.socket                                                                                                loaded    active   running   Journal Socket
+  systemd-networkd.socket                                                                                                loaded    inactive dead      Network Service Netlink Socket
+  systemd-pcrextend.socket                                                                                               loaded    inactive dead      TPM2 PCR Extension (Varlink)
+  systemd-rfkill.socket                                                                                                  loaded    active   listening Load/Save RF Kill Switch Status /dev/rfkill Watch
+  systemd-sysext.socket                                                                                                  loaded    active   listening System Extension Image Management (Varlink)
+  systemd-udevd-control.socket                                                                                           loaded    active   running   udev Control Socket
+  systemd-udevd-kernel.socket                                                                                            loaded    active   running   udev Kernel Socket
+  uuidd.socket                                                                                                           loaded    active   listening UUID daemon activation socket
+  dev-disk-by\x2did-dm\x2dname\x2dvgkubuntu\x2dswap_1.swap                                                               loaded    active   active    /dev/disk/by-id/dm-name-vgkubuntu-swap_1
+  dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dRoD89g5mYULmxHElrSKDCmJut5r4Ov35tRNLpfM3RF32wqL3m3M5K458cDSBHwzw.swap           loaded    active   active    /dev/disk/by-id/dm-uuid-LVM-RoD89g5mYULmxHElrSKDCmJut5r4Ov35tRNLpfM3RF32wqL3m3M5K458cDSBHwzw
+  dev-disk-by\x2duuid-ae77b0f7\x2d5356\x2d4798\x2da1b9\x2d11562a6a95ad.swap                                              loaded    active   active    /dev/disk/by-uuid/ae77b0f7-5356-4798-a1b9-11562a6a95ad
+  dev-dm\x2d2.swap                                                                                                       loaded    active   active    /dev/dm-2
+  dev-mapper-vgkubuntu\x2dswap_1.swap                                                                                    loaded    active   active    /dev/mapper/vgkubuntu-swap_1
+  dev-vgkubuntu-swap_1.swap                                                                                              loaded    active   active    /dev/vgkubuntu/swap_1
+  basic.target                                                                                                           loaded    active   active    Basic System
+  blockdev@dev-disk-by\x2duuid-A123\x2dF910.target                                                                       loaded    inactive dead      Block Device Preparation for /dev/disk/by-uuid/A123-F910
+  blockdev@dev-disk-by\x2duuid-b4eecb14\x2d2be9\x2d4f11\x2d8003\x2dfaa099d4fb6c.target                                   loaded    inactive dead      Block Device Preparation for /dev/disk/by-uuid/b4eecb14-2be9-4f11-8003-faa099d4fb6c
+  blockdev@dev-dm\x2d2.target                                                                                            loaded    inactive dead      Block Device Preparation for /dev/dm-2
+  blockdev@dev-loop0.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop0
+  blockdev@dev-loop1.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop1
+  blockdev@dev-loop10.target                                                                                             loaded    inactive dead      Block Device Preparation for /dev/loop10
+  blockdev@dev-loop11.target                                                                                             loaded    inactive dead      Block Device Preparation for /dev/loop11
+  blockdev@dev-loop12.target                                                                                             loaded    inactive dead      Block Device Preparation for /dev/loop12
+  blockdev@dev-loop2.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop2
+  blockdev@dev-loop3.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop3
+  blockdev@dev-loop4.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop4
+  blockdev@dev-loop5.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop5
+  blockdev@dev-loop6.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop6
+  blockdev@dev-loop7.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop7
+  blockdev@dev-loop8.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop8
+  blockdev@dev-loop9.target                                                                                              loaded    inactive dead      Block Device Preparation for /dev/loop9
+  blockdev@dev-mapper-nvme0n1p3_crypt.target                                                                             loaded    active   active    Block Device Preparation for /dev/mapper/nvme0n1p3_crypt
+  blockdev@dev-mapper-vgkubuntu\x2droot.target                                                                           loaded    inactive dead      Block Device Preparation for /dev/mapper/vgkubuntu-root
+  blockdev@dev-mapper-vgkubuntu\x2dswap_1.target                                                                         loaded    inactive dead      Block Device Preparation for /dev/mapper/vgkubuntu-swap_1
+  blockdev@dev-nvme0n1p1.target                                                                                          loaded    inactive dead      Block Device Preparation for /dev/nvme0n1p1
+  blockdev@dev-nvme0n1p2.target                                                                                          loaded    inactive dead      Block Device Preparation for /dev/nvme0n1p2
+  bluetooth.target                                                                                                       loaded    active   active    Bluetooth Support
+  cryptsetup-pre.target                                                                                                  loaded    inactive dead      Local Encrypted Volumes (Pre)
+  cryptsetup.target                                                                                                      loaded    active   active    Local Encrypted Volumes
+● display-manager.target                                                                                                 not-found inactive dead      display-manager.target
+  emergency.target                                                                                                       loaded    inactive dead      Emergency Mode
+  final.target                                                                                                           loaded    inactive dead      Late Shutdown Services
+  first-boot-complete.target                                                                                             loaded    inactive dead      First Boot Complete
+  getty-pre.target                                                                                                       loaded    active   active    Preparation for Logins
+  getty.target                                                                                                           loaded    active   active    Login Prompts
+  graphical.target                                                                                                       loaded    active   active    Graphical Interface
+● hibernate.target                                                                                                       masked    inactive dead      hibernate.target
+  hybrid-sleep.target                                                                                                    loaded    inactive dead      Hybrid Suspend+Hibernate
+  initrd-fs.target                                                                                                       loaded    inactive dead      Initrd File Systems
+  initrd-root-device.target                                                                                              loaded    inactive dead      Initrd Root Device
+  initrd-root-fs.target                                                                                                  loaded    inactive dead      Initrd Root File System
+  initrd-switch-root.target                                                                                              loaded    inactive dead      Switch Root
+  initrd-usr-fs.target                                                                                                   loaded    inactive dead      Initrd /usr File System
+  initrd.target                                                                                                          loaded    inactive dead      Initrd Default Target
+  integritysetup.target                                                                                                  loaded    active   active    Local Integrity Protected Volumes
+  local-fs-pre.target                                                                                                    loaded    active   active    Preparation for Local File Systems
+  local-fs.target                                                                                                        loaded    active   active    Local File Systems
+  multi-user.target                                                                                                      loaded    active   active    Multi-User System
+  network-online.target                                                                                                  loaded    active   active    Network is Online
+  network-pre.target                                                                                                     loaded    active   active    Preparation for Network
+  network.target                                                                                                         loaded    active   active    Network
+  nss-lookup.target                                                                                                      loaded    active   active    Host and Network Name Lookups
+  nss-user-lookup.target                                                                                                 loaded    active   active    User and Group Name Lookups
+  paths.target                                                                                                           loaded    active   active    Path Units
+  remote-cryptsetup.target                                                                                               loaded    inactive dead      Remote Encrypted Volumes
+  remote-fs-pre.target                                                                                                   loaded    inactive dead      Preparation for Remote File Systems
+  remote-fs.target                                                                                                       loaded    active   active    Remote File Systems
+  remote-veritysetup.target                                                                                              loaded    inactive dead      Remote Verity Protected Volumes
+  rescue.target                                                                                                          loaded    inactive dead      Rescue Mode
+  shutdown.target                                                                                                        loaded    inactive dead      System Shutdown
+  sleep.target                                                                                                           loaded    inactive dead      Sleep
+  slices.target                                                                                                          loaded    active   active    Slice Units
+  snapd.mounts-pre.target                                                                                                loaded    active   active    Mounting snaps
+  snapd.mounts.target                                                                                                    loaded    active   active    Mounted snaps
+  sockets.target                                                                                                         loaded    active   active    Socket Units
+  soft-reboot.target                                                                                                     loaded    inactive dead      Reboot System Userspace
+  sound.target                                                                                                           loaded    active   active    Sound Card
+  suspend-then-hibernate.target                                                                                          loaded    inactive dead      Suspend; Hibernate if not used for a period of time
+● suspend.target                                                                                                         masked    inactive dead      suspend.target
+  swap.target                                                                                                            loaded    active   active    Swaps
+  sysinit.target                                                                                                         loaded    active   active    System Initialization
+  time-set.target                                                                                                        loaded    active   active    System Time Set
+  time-sync.target                                                                                                       loaded    inactive dead      System Time Synchronized
+  timers.target                                                                                                          loaded    active   active    Timer Units
+  umount.target                                                                                                          loaded    inactive dead      Unmount All Filesystems
+  veritysetup-pre.target                                                                                                 loaded    inactive dead      Local Verity Protected Volumes (Pre)
+  veritysetup.target                                                                                                     loaded    active   active    Local Verity Protected Volumes
+  anacron.timer                                                                                                          loaded    active   waiting   Trigger anacron every hour
+  apport-autoreport.timer                                                                                                loaded    inactive dead      Process error reports when automatic reporting is enabled (timer based)
+  apt-daily-upgrade.timer                                                                                                loaded    active   waiting   Daily apt upgrade and clean activities
+  apt-daily.timer                                                                                                        loaded    active   waiting   Daily apt download activities
+  dpkg-db-backup.timer                                                                                                   loaded    active   waiting   Daily dpkg database backup timer
+  e2scrub_all.timer                                                                                                      loaded    active   waiting   Periodic ext4 Online Metadata Check for All Filesystems
+  fstrim.timer                                                                                                           loaded    active   waiting   Discard unused filesystem blocks once a week
+  fwupd-refresh.timer                                                                                                    loaded    active   waiting   Refresh fwupd metadata regularly
+  logrotate.timer                                                                                                        loaded    active   waiting   Daily rotation of log files
+  man-db.timer                                                                                                           loaded    active   waiting   Daily man-db regeneration
+  motd-news.timer                                                                                                        loaded    active   waiting   Message of the Day
+  phpsessionclean.timer                                                                                                  loaded    active   waiting   Clean PHP session files every 30 mins
+  plocate-updatedb.timer                                                                                                 loaded    active   waiting   Update the plocate database daily
+  snapd.snap-repair.timer                                                                                                loaded    inactive dead      Timer to automatically fetch and run repair assertions
+  systemd-tmpfiles-clean.timer                                                                                           loaded    active   waiting   Daily Cleanup of Temporary Directories
+  ua-timer.timer                                                                                                         loaded    active   waiting   Ubuntu Pro Timer for running repeated jobs
+  update-notifier-download.timer                                                                                         loaded    active   waiting   Download data for packages that failed at package install time
+  update-notifier-motd.timer                                                                                             loaded    active   waiting   Check to see whether there is a new version of Ubuntu available
+
+Legend: LOAD   → Reflects whether the unit definition was properly loaded.
+        ACTIVE → The high-level unit activation state, i.e. generalization of SUB.
+        SUB    → The low-level unit activation state, values depend on unit type.
+
+571 loaded units listed.
+To show all installed unit files use 'systemctl list-unit-files'.

--- a/monitoring-agent-daemon/resources/test/systemctl_uuidd_inactive.out
+++ b/monitoring-agent-daemon/resources/test/systemctl_uuidd_inactive.out
@@ -1,0 +1,9 @@
+  UNIT                                                                                                                   LOAD      ACTIVE   SUB       DESCRIPTION
+  uuidd.service                                                                                                          loaded    inactive dead      Daemon for generating UUIDs
+
+Legend: LOAD   → Reflects whether the unit definition was properly loaded.
+        ACTIVE → The high-level unit activation state, i.e. generalization of SUB.
+        SUB    → The low-level unit activation state, values depend on unit type.
+
+571 loaded units listed.
+To show all installed unit files use 'systemctl list-unit-files'.

--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -71,6 +71,15 @@
                 "maxPercentageSwapUsed": 2.0,
                 "storeValues": true
             }
+        },
+        {
+            "name":"Systemctl",
+            "schedule": "*/5 * * * * *",
+            "details": {
+                "type": "systemctl",
+                "active": ["uuidd", "ssh"],
+                "storeValues": true
+            }
         }
     ]
 }

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -68,6 +68,10 @@ pub enum MonitorType {
         #[serde(rename = "storeValues", default = "default_as_false")]
         store_values: bool,    
     },   
+    Systemctl {
+        #[serde(rename = "active")]
+        active: Vec<String>,
+    },   
 }
 
 /**

--- a/monitoring-agent-daemon/src/services/monitors/mod.rs
+++ b/monitoring-agent-daemon/src/services/monitors/mod.rs
@@ -13,6 +13,7 @@ mod httpmonitor;
 mod tcpmonitor;
 mod loadavgmonitor;
 mod meminfomonitor;
+mod systemctlmonitor;
 
 pub use common::Monitor;
 pub use commandmonitor::CommandMonitor;
@@ -20,3 +21,4 @@ pub use httpmonitor::HttpMonitor;
 pub use tcpmonitor::TcpMonitor;
 pub use loadavgmonitor::LoadAvgMonitor;
 pub use meminfomonitor::MeminfoMonitor;
+pub use systemctlmonitor::SystemctlMonitor;

--- a/monitoring-agent-daemon/src/services/monitors/systemctlmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/systemctlmonitor.rs
@@ -1,0 +1,243 @@
+use std::{collections::{HashMap, HashSet}, sync::{Arc, Mutex}};
+
+use log::{debug, error, info};
+use tokio_cron_scheduler::Job;
+
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::DbService};
+
+use super::Monitor;
+
+#[derive(Debug, Clone)]
+pub struct SystemctlMonitor {
+    /// The name of the monitor.
+    pub name: String,
+    /// The status of the monitor.
+    pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
+    /// The database service.
+    database_service: Arc<Option<DbService>>,
+    /// The database store level.
+    database_store_level: DatabaseStoreLevel,
+    /// The services to monitor.
+    active: Vec<String>,
+}
+
+impl SystemctlMonitor {
+    /**
+     * Create a new Systemctl monitor.
+     *
+     * name: The name of the monitor.
+     * status: The status of the monitor.
+     * database_service: The database service.
+     * database_store_level: The database store level.
+     * active: The services to monitor.
+     *
+     */
+    pub fn new(
+        name: &str,
+        status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
+        database_service: &Arc<Option<DbService>>,
+        database_store_level: &DatabaseStoreLevel,
+        active: Vec<String>,
+    ) -> SystemctlMonitor {
+        debug!("Creating Systemctl monitor: {}", &name);
+        let status_lock = status.lock();
+        match status_lock {
+            Ok(mut lock) => {
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+            }
+            Err(err) => {
+                error!("Error creating systemctl monitor: {err:?}");
+            }
+        }        
+        SystemctlMonitor {
+            name: name.to_string(),
+            status: status.clone(),
+            database_service: database_service.clone(),
+            database_store_level: database_store_level.clone(),
+            active,
+        }
+    }
+
+    /**
+     * Get systemctl job.
+     *
+     * `schedule``: The schedule for the job.
+     */
+    pub fn get_systemctl_monitor_job(
+        &mut self,
+        schedule: &str,
+    ) -> Result<Job, ApplicationError> {
+        info!("Creating Tcp monitor: {}", &self.name);
+        let systemctl_monitor = self.clone();
+        let job_result = Job::new_async(schedule, move |_uuid, _locked| {
+            let systemctl_monitor = systemctl_monitor.clone();
+            Box::pin(async move {
+                systemctl_monitor.clone().check().await;
+            })              
+        });        
+        match job_result {
+            Ok(job) => Ok(job),
+            Err(err) => Err(ApplicationError::new(
+                format!("Could not create job: {err}").as_str(),
+            )),
+        }
+    }
+
+    /**
+     * Check the monitor.
+     */
+    async fn check(&mut self) {
+        let output = tokio::process::Command::new("systemctl")
+            .arg("--all")
+            .output()
+            .await
+            .expect("failed to execute process");
+        let command_output = String::from_utf8_lossy(&output.stdout);        
+        let non_active = self.get_nonactive_status(&command_output).await;
+        let error_message = format!("Non-active services: {:?}", non_active);
+        if non_active.len() > 0 {
+            self.set_status(&Status::Error { message: error_message }).await;
+        } else {
+            self.set_status(&Status::Ok).await;
+        }        
+    }
+
+    /**
+     * Get the non-active status.
+     * 
+     * `command_output`: The command output.
+     * 
+     * Returns: The non-active services.
+     */
+    async fn get_nonactive_status(&self, command_output: &str) -> Vec<String> {
+        let mut non_active: Vec<String> = vec![];
+        let active_set: HashSet<String> = HashSet::from_iter(self.active.iter().cloned());
+        for line in command_output.lines() {
+            let data = line.split_whitespace().collect::<Vec<&str>>();
+            if data.len() >= 3 && active_set.contains(&(data[0].replace(".service", "").to_owned()).to_string()) {
+                if data[2] != "active" {
+                    non_active.push(data[0].to_string());
+                }
+            }
+        }
+        non_active
+    }
+
+}
+
+/**
+ * Implement the `Monitor` trait for `SystemctlMonitor`.
+ */
+impl super::Monitor for SystemctlMonitor {
+    /**
+     * Get the name of the monitor.
+     *
+     * Returns: The name of the monitor.
+     */
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /**
+     * Get the status of the monitor.
+     *
+     * Returns: The status of the monitor.
+     */
+    fn get_status(&self) -> Arc<Mutex<HashMap<String, MonitorStatus>>> {
+        self.status.clone()
+    }
+
+    /**
+     * Get the database service.
+     *
+     * Returns: The database service.
+     */
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
+        self.database_service.clone()
+    }
+
+    /**
+     * Get the database store level.
+     *
+     * Returns: The database store level.
+     */
+    fn get_database_store_level(&self) -> DatabaseStoreLevel {
+        self.database_store_level.clone()
+    }    
+ 
+}
+
+#[cfg(test)]
+mod test {
+    
+    use std::fs;
+
+    use super::*;
+    use crate::services::monitors::common::Monitor;
+
+    /**
+     * Verifies that the command monitor can be run.
+     */
+    #[tokio::test]
+    async fn test_check() {
+        let status = Arc::new(Mutex::new(HashMap::new()));
+        let database_service = Arc::new(None);
+        let database_store_level = DatabaseStoreLevel::None;
+        let active = vec![  ];
+        let systemctl_monitor = SystemctlMonitor::new(
+            "test",
+            &status,
+            &database_service,
+            &database_store_level,
+            active,
+        );
+        systemctl_monitor.clone().check().await;
+        let status = systemctl_monitor.get_status();
+        let lock = status.lock().unwrap();
+        let monitor_status = lock.get("test").unwrap();
+        assert_eq!(&monitor_status.status, &Status::Ok);
+    }
+
+    /**
+     * Test the Systemctl monitor without checking any.
+     */
+    #[tokio::test]
+    async fn test_systemctl_monitor_with_no_active() {
+        let status = Arc::new(Mutex::new(HashMap::new()));
+        let database_service = Arc::new(None);
+        let database_store_level = DatabaseStoreLevel::None;
+        let active = vec![ "ssh".to_string() ];
+        let systemctl_monitor = SystemctlMonitor::new(
+            "test",
+            &status,
+            &database_service,
+            &database_store_level,
+            active,
+        );
+        let command_str = String::from_utf8(fs::read("resources/test/systemctl_test.out").unwrap()).unwrap();
+        let non_active = systemctl_monitor.get_nonactive_status(command_str.as_str()).await;
+        assert_eq!(non_active.len(), 0);
+    }
+
+    /**
+     * Test the Systemctl monitor checking uuidd inactive.
+     */
+    #[tokio::test]
+    async fn test_systemctl_monitor_with_uuidd_inactive() {
+        let status = Arc::new(Mutex::new(HashMap::new()));
+        let database_service = Arc::new(None);
+        let database_store_level = DatabaseStoreLevel::None;
+        let active = vec![ "uuidd".to_string() ];
+        let systemctl_monitor = SystemctlMonitor::new(
+            "test",
+            &status,
+            &database_service,
+            &database_store_level,
+            active,
+        );
+        let command_str = String::from_utf8(fs::read("resources/test/systemctl_uuidd_inactive.out").unwrap()).unwrap();
+        let non_active = systemctl_monitor.get_nonactive_status(command_str.as_str()).await;
+        assert_eq!(non_active.len(), 1);
+    }    
+
+}

--- a/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
@@ -155,8 +155,6 @@ impl TcpMonitor {
 
 }
 
-
-
 /**
  * Implement the `Monitor` trait for `TcpMonitor`.
  */

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -5,7 +5,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{configuration::MonitoringConfig, ApplicationError, MonitorStatus};
 use crate::services::DbService;
-use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, TcpMonitor, MeminfoMonitor};
+use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, MeminfoMonitor, SystemctlMonitor, TcpMonitor};
 
 /**
  * Scheduling Service.
@@ -191,6 +191,11 @@ impl SchedulingService {
             } => {
                 let mut meminfo_monitor = MeminfoMonitor::new(&monitor.name, max_percentage_mem, max_percentage_swap, &self.status, &self.database_service.clone(), &monitor.store, store_values);
                 let job = meminfo_monitor.get_meminfo_monitor_job(monitor.schedule.as_str())?;
+                self.add_job(scheduler, job).await
+            },
+            crate::common::MonitorType::Systemctl { active } => {
+                let mut systemctl_monitor = SystemctlMonitor::new(&monitor.name, &self.status, &self.database_service.clone(), &monitor.store, active);
+                let job = systemctl_monitor.get_systemctl_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
         }?;   


### PR DESCRIPTION
Implements a new monitor for systemctl. This monitor will check if a
service is active. The monitors checks if the service is active and
if it is not active, it will return an error state.

The monitor allows for a list of services to be monitored.

Breaking changes: None

Resolves: https://github.com/kjetilfjellheim/monitoring-agent/issues/5