### PR TITLE
feat: Issue-15 Add Database Monitor

### DIFF
--- a/monitoring-agent-daemon/resources/test/test_full_integration_test.json
+++ b/monitoring-agent-daemon/resources/test/test_full_integration_test.json
@@ -16,7 +16,7 @@
     "monitors":[
         {
             "name":"Apache TCP",
-            "schedule": "*/5 * * * * *",
+            "schedule": "*/1 * * * * *",
             "details": {
                 "type": "tcp",
                 "host": "127.0.0.1",
@@ -25,7 +25,7 @@
         },
         {
             "name":"Netbios TCP",
-            "schedule": "*/5 * * * * *",
+            "schedule": "*/1 * * * * *",
             "details": {
                 "type": "tcp",
                 "host": "127.0.0.1",
@@ -34,7 +34,7 @@
         },
         {
             "name":"Apache Http",
-            "schedule": "*/5 * * * * *",
+            "schedule": "*/1 * * * * *",
             "details": {
                 "type": "http",
                 "url": "http://localhost",
@@ -43,7 +43,7 @@
         },
         {
             "name":"Systemctl memcached",
-            "schedule": "*/5 * * * * *",
+            "schedule": "*/1 * * * * *",
             "details": {
                 "type": "command",
                 "command": "systemctl",
@@ -53,7 +53,7 @@
         },
         {
             "name":"Loadavg",
-            "schedule": "*/5 * * * * *",
+            "schedule": "*/1 * * * * *",
             "details": {
                 "type": "loadAvg",
                 "threshold1min": 2.0,
@@ -64,7 +64,7 @@
         },
         {
             "name":"Mem",
-            "schedule": "*/5 * * * * *",
+            "schedule": "*/1 * * * * *",
             "details": {
                 "type": "mem",
                 "maxPercentageMemUsed": 2.0,
@@ -74,11 +74,47 @@
         },
         {
             "name":"Systemctl",
-            "schedule": "*/5 * * * * *",
+            "schedule": "*/1 * * * * *",
             "details": {
                 "type": "systemctl",
                 "active": ["uuidd", "ssh"],
                 "storeValues": true
+            }
+        },
+        {
+            "name":"Database postgres",
+            "schedule": "*/1 * * * * *",
+            "details": {
+                "type": "database",
+                "maxQueryTime": 30,
+                "config": {
+                    "type": "Postgres",
+                    "host": "greyhawk.forgottendonkey.com",
+                    "port": 5432,
+                    "user": "monitor-agent-rw",
+                    "password": "[vKsoUcgY0CqHfKU",
+                    "database": "monitor-agent",
+                    "minConnections": 10,
+                    "maxConnections": 100
+                }
+            }
+        },
+        {
+            "name":"Database mariadb",
+            "schedule": "*/1 * * * * *",
+            "details": {
+                "type": "database",
+                "maxQueryTime": 30,
+                "config": {
+                    "type": "Maria",
+                    "host": "greyhawk.forgottendonkey.com",
+                    "port": 3306,
+                    "user": "kjetil",
+                    "password": "!CommodoreAmiga_64",
+                    "database": "monitor-agent",
+                    "minConnections": 10,
+                    "maxConnections": 100
+                }
             }
         }
     ]

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -71,7 +71,14 @@ pub enum MonitorType {
     Systemctl {
         #[serde(rename = "active")]
         active: Vec<String>,
-    },   
+    },
+    Database {
+        /// Database config. If not given then use the global database config.
+        #[serde(skip_serializing_if = "Option::is_none", rename = "config")]
+        database_config: Option<DatabaseConfig>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "maxQueryTime")]
+        max_query_time: Option<u32>,          
+    },    
 }
 
 /**

--- a/monitoring-agent-daemon/src/common/mod.rs
+++ b/monitoring-agent-daemon/src/common/mod.rs
@@ -13,5 +13,5 @@ pub mod args;
 
 pub use crate::common::applicationerror::ApplicationError;
 pub use crate::common::monitorstatus::{MonitorStatus, Status};
-pub use crate::common::configuration::{Monitor, MonitorType, HttpMethod};
+pub use crate::common::configuration::{Monitor, MonitorType, HttpMethod, DatabaseConfig};
 pub use crate::common::args::ApplicationArguments;

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -98,8 +98,9 @@ async fn start_application(monitoring_config: &MonitoringConfig, args: &Applicat
     let cloned_monitoring_config = monitoring_config.clone();
     let cloned_args = args.clone();
     let monitor_statuses = monitoring_service.get_status();
+    let server_name = monitoring_config.server.name.clone();
     tokio::spawn(async move {
-        let mut scheduling_service = SchedulingService::new(&cloned_monitoring_config, &monitor_statuses, &database_service.clone());
+        let mut scheduling_service = SchedulingService::new(&server_name, &cloned_monitoring_config, &monitor_statuses, &database_service.clone());
         match scheduling_service.start(cloned_args.test).await {
             Ok(()) => {
                 info!("Scheduling service started!");

--- a/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
@@ -179,9 +179,6 @@ impl CommandMonitor {
 
 }
 
-
-
-
 /**
  * Implement the `Monitor` trait for `HttpMonitor`.
  */

--- a/monitoring-agent-daemon/src/services/monitors/databasemonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/databasemonitor.rs
@@ -1,0 +1,171 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use log::{error, info};
+use tokio_cron_scheduler::Job;
+
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::{monitors::Monitor, DbService}};
+
+/**
+ * Database monitor.
+ * 
+ * This struct represents a database monitor.
+ * 
+ * `name`: The name of the monitor.
+ * `query_max_time`: The max query time.
+ * `status`: The status of the monitor.
+ * `database_service`: The database service.
+ * `database_store_level`: The database store level.
+ */
+#[derive(Debug, Clone)]
+pub struct DatabaseMonitor {
+    /// The name of the monitor.
+    pub name: String,
+    /// Max query time.
+    pub query_max_time: Option<u32>,
+    /// The current status of the monitor.
+    pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
+    /// The database service.
+    database_service: Arc<Option<DbService>>,   
+    /// The database store level.
+    database_store_level: DatabaseStoreLevel,        
+}
+
+impl DatabaseMonitor {
+    /**
+     * Create a new database monitor.
+     *
+     * `name`: The name of the monitor.
+     * `query_max_time`: The max query time.
+     * `status`: The status of the monitor.
+     * `database_service`: The database service.
+     * `database_store_level`: The database store level.
+     * 
+     * Returns a new `DatabaseMonitor`.
+     */
+    pub fn new(
+        name: &str,
+        query_max_time: Option<u32>,
+        status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
+        database_service: &Arc<Option<DbService>>,
+        database_store_level: &DatabaseStoreLevel,
+    ) -> DatabaseMonitor {
+
+        let status_lock = status.lock();
+        match status_lock {
+            Ok(mut lock) => {
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(),Status::Unknown));
+            }
+            Err(err) => {
+                error!("Error creating command monitor: {:?}", err);
+            }
+        }
+
+        DatabaseMonitor {
+            name: name.to_string(),
+            query_max_time,
+            status: status.clone(),
+            database_service: database_service.clone(),
+            database_store_level: database_store_level.clone(),
+        }
+    }
+
+        /**
+     * Get meminfo monitor job.
+     * 
+     * `schedule`: The schedule for the job.
+     * 
+     * Returns: The meminfo monitor job.
+     * 
+     */
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::similar_names)]    
+    pub fn get_database_monitor_job(
+        &mut self,
+        schedule: &str,
+    ) -> Result<Job, ApplicationError> {
+        info!("Creating database monitor: {}", &self.name);
+        let database_monitor = self.clone();       
+        let job_result = Job::new_async(schedule, move |_uuid, _locked| {                
+            let mut database_monitor = database_monitor.clone();
+            Box::pin(async move {
+                database_monitor.check().await;
+            })  
+        });        
+        match job_result {
+            Ok(job) => Ok(job),
+            Err(err) => Err(ApplicationError::new(
+                format!("Could not create job: {err}").as_str(),
+            )), 
+        }
+    }   
+
+    /**
+     * Check the status of the database.
+     */
+    async fn check(&mut self) {
+        let Some(database_service) = &*self.database_service else {
+            error!("Database service not found.");
+                return;
+        };
+        let mut status = Status::Ok;
+        if self.query_max_time.is_some() {
+            let overtimed_query = match database_service.query_long_running_queries(self.query_max_time.unwrap()).await {
+                Ok(query) => query,
+                Err(err) => {
+                    error!("Error checking query time: {:?}", err);
+                    return;
+                }
+            };
+            if !overtimed_query.is_empty() {
+                status = Status::Error {
+                    message: format!("Long queries found: {overtimed_query:?}"),
+                };
+            }
+        }
+        self.set_status(&status).await;
+    
+    } 
+
+}
+
+/**
+ * Implement the `Monitor` trait for `HttpMonitor`.
+ */
+impl super::Monitor for DatabaseMonitor {
+    /**
+     * Get the name of the monitor.
+     *
+     * Returns: The name of the monitor.
+     */
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /**
+     * Get the status of the monitor.
+     *
+     * Returns: The status of the monitor.
+     */
+    fn get_status(&self) -> Arc<Mutex<HashMap<String, MonitorStatus>>> {
+        self.status.clone()
+    }
+
+    /**
+     * Get the database service.
+     *
+     * Returns: The database service.
+     */
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
+        self.database_service.clone()
+    }
+ 
+    /**
+     * Get the database store level.
+     *
+     * Returns: The database store level.
+     */
+    fn get_database_store_level(&self) -> DatabaseStoreLevel {
+        self.database_store_level.clone()
+    }   
+
+}

--- a/monitoring-agent-daemon/src/services/monitors/mod.rs
+++ b/monitoring-agent-daemon/src/services/monitors/mod.rs
@@ -6,6 +6,9 @@
  * `httpmonitor`: Monitor that checks the status of an HTTP service.
  * `tcpmonitor`: Monitor that checks the status of a TCP service. 
  * `loadavgmonitor`: Monitor that checks the load average of the system.
+ * `meminfomonitor`: Monitor that checks the memory information of the system.
+ * `systemctlmonitor`: Monitor that checks the status of a systemd service.
+ * `databasemonitor`: Monitor that checks the status of a database service.
  */
 mod common;
 mod commandmonitor;
@@ -14,6 +17,7 @@ mod tcpmonitor;
 mod loadavgmonitor;
 mod meminfomonitor;
 mod systemctlmonitor;
+mod databasemonitor;
 
 pub use common::Monitor;
 pub use commandmonitor::CommandMonitor;
@@ -22,3 +26,4 @@ pub use tcpmonitor::TcpMonitor;
 pub use loadavgmonitor::LoadAvgMonitor;
 pub use meminfomonitor::MeminfoMonitor;
 pub use systemctlmonitor::SystemctlMonitor;
+pub use databasemonitor::DatabaseMonitor;

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -5,7 +5,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{configuration::MonitoringConfig, ApplicationError, MonitorStatus};
 use crate::services::DbService;
-use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, MeminfoMonitor, SystemctlMonitor, TcpMonitor};
+use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, MeminfoMonitor, SystemctlMonitor, TcpMonitor, DatabaseMonitor};
 
 /**
  * Scheduling Service.
@@ -14,6 +14,9 @@ use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, MeminfoMonito
  * 
  * `scheduler`: The job scheduler.
  * `monitoring_config`: The monitoring configuration.
+ * `status`: The status of the monitors.
+ * `database_service`: The database service.
+ * `server_name`: The server name.
  * 
  */
 pub struct SchedulingService {
@@ -25,6 +28,8 @@ pub struct SchedulingService {
     status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
     database_service: Arc<Option<DbService>>,
+    /// The server name.
+    server_name: String,
 }
 
 impl SchedulingService {
@@ -34,12 +39,13 @@ impl SchedulingService {
      *
      * result: The result of creating the scheduling service.
      */
-    pub fn new(monitoring_config: &MonitoringConfig, status: &Arc<Mutex<HashMap<String, MonitorStatus>>>, database_service: &Arc<Option<DbService>>) -> SchedulingService {
+    pub fn new(server_name: &str, monitoring_config: &MonitoringConfig, status: &Arc<Mutex<HashMap<String, MonitorStatus>>>, database_service: &Arc<Option<DbService>>) -> SchedulingService {
         SchedulingService {
             scheduler: None,
             monitoring_config: monitoring_config.clone(),
             status: status.clone(),
             database_service: database_service.clone(),
+            server_name: server_name.to_string(),
         }
     }
 
@@ -193,13 +199,46 @@ impl SchedulingService {
                 let job = meminfo_monitor.get_meminfo_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
-            crate::common::MonitorType::Systemctl { active } => {
+            crate::common::MonitorType::Systemctl { active 
+            } => {
                 let mut systemctl_monitor = SystemctlMonitor::new(&monitor.name, &self.status, &self.database_service.clone(), &monitor.store, active);
                 let job = systemctl_monitor.get_systemctl_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
+            crate::common::MonitorType::Database {database_config, max_query_time,
+            } => {
+                let mut database_monitor = DatabaseMonitor::new(
+                    &monitor.name,
+                    max_query_time,
+                    &self.status,
+                    &self.get_database_service(&self.database_service, &database_config).await?,
+                    &monitor.store,
+                );
+                let job = database_monitor.get_database_monitor_job(monitor.schedule.as_str())?;
+                self.add_job(scheduler, job).await
+            },
         }?;   
         Ok(()) 
+    }
+
+    /**
+     * Get the database service.
+     *
+     * `database_service`: The database service.
+     * `database_config`: The database configuration.
+     *
+     * `result`: The result of getting the database service.
+     *
+     * throws: `ApplicationError`: If the database service fails to be created.
+     */
+    async fn get_database_service(&self, database_service: &Arc<Option<DbService>>, database_config: &Option<crate::common::DatabaseConfig>) -> Result<Arc<Option<DbService>>, ApplicationError> {
+        match database_config {
+            Some(database_config) => {
+                let database_service = DbService::new(database_config, &self.server_name).await?;
+                Ok(Arc::new(Some(database_service)))
+            },
+            None => Ok(database_service.clone()),
+        }
     }
 
     /**
@@ -237,7 +276,7 @@ mod test {
     #[tokio::test]
     async fn test_monitoring_service() {
         let status = Arc::new(Mutex::new(HashMap::new()));
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_full_integration_test.json").unwrap(), &status, &Arc::new(None));
+        let mut scheduling_service = SchedulingService::new("", &MonitoringConfig::new("./resources/test/test_full_integration_test.json").unwrap(), &status, &Arc::new(None));
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }
@@ -248,7 +287,7 @@ mod test {
     #[tokio::test]
     async fn test_monitoring_service_tcp() {
         let status = Arc::new(Mutex::new(HashMap::new()));
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_tcp.json").unwrap(), &status, &Arc::new(None));
+        let mut scheduling_service = SchedulingService::new("", &MonitoringConfig::new("./resources/test/test_simple_tcp.json").unwrap(), &status, &Arc::new(None));
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }
@@ -259,7 +298,7 @@ mod test {
     #[tokio::test]
     async fn test_monitoring_service_http() {
         let status = Arc::new(Mutex::new(HashMap::new()));
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_http.json").unwrap(), &status, &Arc::new(None));
+        let mut scheduling_service = SchedulingService::new("", &MonitoringConfig::new("./resources/test/test_simple_http.json").unwrap(), &status, &Arc::new(None));
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }
@@ -270,7 +309,7 @@ mod test {
     #[tokio::test]
     async fn test_monitoring_service_command() {
         let status = Arc::new(Mutex::new(HashMap::new()));
-        let mut scheduling_service = SchedulingService::new(&MonitoringConfig::new("./resources/test/test_simple_command.json").unwrap(), &status, &Arc::new(None));
+        let mut scheduling_service = SchedulingService::new("", &MonitoringConfig::new("./resources/test/test_simple_command.json").unwrap(), &status, &Arc::new(None));
         let res = scheduling_service.start(true).await;
         assert!(res.is_ok());
     }


### PR DESCRIPTION
Adds a new monitor to the monitoring agent that will monitor the database for long running queries. This monitor will be able to detect queries that are running for longer than a specified time and the daemon will report it as an error.

Breaking changes: None

Resolves: #15