### PR TITLE
feat:Issue-113: Implement process monitor

### DIFF
--- a/monitoring-agent-daemon/resources/test/configuration_import_test/test_full_integration.json
+++ b/monitoring-agent-daemon/resources/test/configuration_import_test/test_full_integration.json
@@ -71,6 +71,16 @@
                 "maxPercentageSwapUsed": 75.0,
                 "storeValues": true
             }
+        },
+        {
+            "name":"Process monitoring-agent-daemon",
+            "schedule": "0 */1 * * * *",
+            "details": {
+                "type": "process",
+                "applicationNames": ["monitoring-agent-daemon"],
+                "maxMemUsage": 100,
+                "storeValues": true
+            }
         }
     ]
 }

--- a/monitoring-agent-daemon/resources/test/configuration_import_test/test_simple_process.json
+++ b/monitoring-agent-daemon/resources/test/configuration_import_test/test_simple_process.json
@@ -1,0 +1,18 @@
+{
+    "server": {
+        "ip": "127.0.0.1",
+        "port": 8080
+    },
+    "monitors":[
+        {
+            "name":"Process monitoring-agent-daemon",
+            "schedule": "0 0 0 0 0 0",
+            "details": {
+                "type": "process",
+                "applicationNames": ["app1", "app2"],
+                "maxMemUsage": 100,
+                "storeValues": true
+            }
+        }
+    ]
+}

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -79,7 +79,18 @@ pub enum MonitorType {
         database_config: Option<DatabaseConfig>,
         #[serde(skip_serializing_if = "Option::is_none", rename = "maxQueryTime")]
         max_query_time: Option<u32>,          
-    },    
+    },
+    Process {
+        /// Aplication names to monitor.
+        #[serde(rename = "applicationNames")]
+        application_names: Vec<String>,
+        /// The maximum memory usage.
+        #[serde(skip_serializing_if = "Option::is_none", rename = "maxMemUsage")]
+        max_mem_usage: Option<u32>,        
+        /// Store vales in database        
+        #[serde(rename = "storeValues", default = "default_as_false")]
+        store_values: bool,         
+    }
 }
 
 /**
@@ -515,6 +526,28 @@ mod tests {
             }
         );
         Ok(())
-    }        
+    }   
+
+    /**
+     * Test for a simple process monitor.
+     */
+    #[test]
+    fn test_simple_process_file() -> Result<(), ApplicationError> {
+        let monitoring: MonitoringConfig =
+            MonitoringConfig::new("resources/test/configuration_import_test/test_simple_process.json")?;
+        assert_eq!("0 0 0 0 0 0".to_string(), monitoring.monitors[0].schedule);
+        assert_eq!(1, monitoring.monitors.len());
+        let monitor = monitoring.monitors[0].details.clone();
+        assert_eq!(
+            monitor,
+            MonitorType::Process { 
+                application_names: vec!["app1".to_string(), "app2".to_string()],
+                max_mem_usage: Some(100),
+                store_values: true,
+                
+            }
+        );
+        Ok(())
+    }             
 
 }

--- a/monitoring-agent-daemon/src/common/monitorstatus.rs
+++ b/monitoring-agent-daemon/src/common/monitorstatus.rs
@@ -81,6 +81,26 @@ pub enum Status {
     Error { message: String },
 }
 
+impl Status {
+    /**
+     * Get the maximum status from a list of statuses.
+     * Ok < Error (Unknown is ignored)
+     *
+     * `statuses`: The list of statuses.
+     *
+     */
+    pub fn get_max_status(statuses: Vec<Status>) -> Status {
+        let mut max_status = Status::Ok;
+        for status in statuses {
+            if let Status::Error { .. } = status {
+                max_status = status;
+            }                
+        }
+        max_status
+    }
+
+}
+
 #[cfg(test)]
 mod test {
 
@@ -117,6 +137,17 @@ mod test {
         assert!(monitorstatus.last_successful_time.is_some());
         assert_eq!(monitorstatus.last_error, Some("test error".to_string()));
         assert!(monitorstatus.last_error_time.is_some());
+    }
+
+    #[test]
+    fn test_status_get_max_status() {
+        let statuses = vec![Status::Ok, Status::Error { message: "test error".to_string() }];
+        let max_status = Status::get_max_status(statuses);
+        assert_eq!(max_status, Status::Error { message: "test error".to_string() });
+
+        let statuses = vec![Status::Ok, Status::Unknown];
+        let max_status = Status::get_max_status(statuses);
+        assert_eq!(max_status, Status::Ok);
     }
 
 }

--- a/monitoring-agent-daemon/src/services/databaseservice.rs
+++ b/monitoring-agent-daemon/src/services/databaseservice.rs
@@ -1,3 +1,4 @@
+use monitoring_agent_lib::proc::Statm;
 use monitoring_agent_lib::proc::{ProcsLoadavg, ProcsMeminfo};
 use r2d2::Pool;
 use r2d2_mysql::mysql::params;
@@ -157,6 +158,13 @@ impl DbService {
         match self {
             DbService::MariaDb(service) => service.query_long_running_queries(max_query_time),
             DbService::PostgresDb(service) => service.query_long_running_queries(max_query_time).await,
+        }
+    }
+
+    pub async fn store_statm_values(&self, app_name: &str, pid: &u32, statm: &Statm) -> Result<(), ApplicationError> {
+        match self {
+            DbService::MariaDb(service) => service.store_statm_values(app_name, pid, statm),
+            DbService::PostgresDb(service) => service.store_statm_values(app_name, pid, statm).await,
         }
     }
 }
@@ -320,6 +328,27 @@ impl MariaDbService {
         }).map_err(|err| ApplicationError::new(&err.to_string()))?;
         tx.commit().map_err(|err| ApplicationError::new(&err.to_string()))?;
         Ok(result)
+    }
+
+    #[tracing::instrument(level = "debug")]
+    fn store_statm_values(&self, app_name: &str, pid: &u32, statm: &Statm) -> Result<(), ApplicationError> {
+        let mut conn = self.pool.get().map_err(|err| ApplicationError::new(&err.to_string()))?;
+        let mut tx = conn.start_transaction(TxOpts::default()).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.exec_drop("INSERT INTO statm (server_name, app_name, log_time, pid, total, resident, share, trs, drs, lrs, dt) VALUES 
+                    (:server_name, :app_name, now(3), :pid, :total, :resident, :share, :trs, :drs, :lrs, :dt)", params! {
+            "server_name" => self.server_name.to_string(),
+            "app_name" => app_name,
+            "pid" => pid,
+            "total" => statm.size,
+            "resident" => statm.resident,
+            "share" => statm.share,
+            "trs" => statm.trs,
+            "drs" => statm.drs,
+            "lrs" => statm.lrs,
+            "dt" => statm.dt,
+        }).map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.commit().map_err(|err| ApplicationError::new(&err.to_string()))?;       
+        Ok(())
     }
 
 }
@@ -488,5 +517,28 @@ impl PostgresDbService {
             queries.push(format!("id: {id}, client: {client}"));
         }
         queries
+    }
+
+    #[tracing::instrument(level = "debug")]
+    async fn store_statm_values(&self, app_name: &str, pid: &u32, statm: &Statm) -> Result<(), ApplicationError> {
+        let mut conn = self.pool.get().await.map_err(|err| ApplicationError::new(&err.to_string()))?;
+        let tx = conn.transaction().await.map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.execute("INSERT INTO statm (id, server_name, app_name, log_time, pid, total, resident, share, trs, drs, lrs, dt) VALUES 
+                    (nextval('seq_statm'), $1, $2, now(), $3, $4, $5, $6, $7, $8, $9)", &[
+            &self.server_name,
+            &app_name,
+            &pid,
+            &statm.size,
+            &statm.resident,
+            &statm.share,
+            &statm.trs,
+            &statm.drs,
+            &statm.lrs,
+            &statm.dt,
+
+        ]).await.map_err(|err| ApplicationError::new(&err.to_string()))?;
+        tx.commit().await.map_err(|err| ApplicationError::new(&err.to_string()))?;
+        Ok(())
+
     }
 }

--- a/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
@@ -142,17 +142,14 @@ impl MeminfoMonitor {
      * `meminfo`: The current load average.
      */
     async fn store_current_meminfo(&self, meminfo: &ProcsMeminfo) {
-        match self.database_service.as_ref() {            
-            Some(database_service) => {
-                match database_service.store_meminfo(meminfo).await {
-                    Ok(()) => {}
-                    Err(err) => {
-                        error!("Error storing memory use: {:?}", err);
-                    }
+        if let Some(database_service) = self.database_service.as_ref() {
+            match database_service.store_meminfo(meminfo).await {
+                Ok(()) => {}
+                Err(err) => {
+                    error!("Error storing memory use: {:?}", err);
                 }
             }
-            None => {}
-        }        
+        }    
     }
 
     /**

--- a/monitoring-agent-daemon/src/services/monitors/mod.rs
+++ b/monitoring-agent-daemon/src/services/monitors/mod.rs
@@ -9,6 +9,7 @@
  * `meminfomonitor`: Monitor that checks the memory information of the system.
  * `systemctlmonitor`: Monitor that checks the status of a systemd service.
  * `databasemonitor`: Monitor that checks the status of a database service.
+ * `processmonitor`: Monitor that checks the status of a process.
  */
 mod common;
 mod commandmonitor;
@@ -18,6 +19,7 @@ mod loadavgmonitor;
 mod meminfomonitor;
 mod systemctlmonitor;
 mod databasemonitor;
+mod processmonitor;
 
 pub use common::Monitor;
 pub use commandmonitor::CommandMonitor;
@@ -27,3 +29,4 @@ pub use loadavgmonitor::LoadAvgMonitor;
 pub use meminfomonitor::MeminfoMonitor;
 pub use systemctlmonitor::SystemctlMonitor;
 pub use databasemonitor::DatabaseMonitor;
+pub use processmonitor::ProcessMonitor;

--- a/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
@@ -1,0 +1,349 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use log::{debug, error, info};
+use monitoring_agent_lib::proc::{CmdLine, Statm};
+use tokio_cron_scheduler::Job;
+
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::DbService};
+
+use super::Monitor;
+
+/**
+ * The `ProcessMonitor` struct represents a moniitor for checking processes.
+ */
+#[derive(Debug, Clone)]
+pub struct ProcessMonitor {
+    /// The monitor name.
+    name: String,
+    /// Application names to monitor.
+    application_names: Vec<String>,
+    /// The max memory usage.
+    max_mem_usage: Option<u32>,
+    /// The status of the monitor.
+    status: Arc<Mutex<HashMap<String, MonitorStatus>>>,    
+    /// The database service
+    database_service: Arc<Option<DbService>>,
+    /// The database store level.
+    database_store_level: DatabaseStoreLevel,
+    /// The current statm.
+    store_current_statm: bool,       
+}
+
+impl ProcessMonitor {
+    /**
+     * Create a new `ProcessMonitor`.
+     * 
+     * `name`: The monitor name.
+     * `application_names`: The application names to monitor.
+     * `max_mem_usage`: The max memory usage.
+     * `status`: The status of the monitor.
+     * `database_service`: The database service.
+     * `database_store_level`: The database store level.
+     * `store_current_statm`: Store the current statm.
+     * 
+     * Returns a new `ProcessMonitor`.
+     */
+    pub fn new(
+        name: &str,
+        application_names: &[String],
+        max_mem_usage: Option<u32>,
+        status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
+        database_service: &Arc<Option<DbService>>,
+        database_store_level: &DatabaseStoreLevel,
+        store_current_statm: bool
+    ) -> ProcessMonitor {
+        debug!("Creating Process monitor: {}", &name);
+        let status_lock = status.lock();
+        match status_lock {
+            Ok(mut lock) => {
+                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+            }
+            Err(err) => {
+                error!("Error creating systemctl monitor: {err:?}");
+            }
+        }            
+        ProcessMonitor {
+            name: name.to_string(),
+            application_names: application_names.to_vec(),
+            max_mem_usage,
+            status: status.clone(),
+            database_service: database_service.clone(),
+            database_store_level: database_store_level.clone(),
+            store_current_statm
+        }
+    }
+
+    /**
+     * Get process job.
+     *
+     * `schedule`: The schedule for the job.
+     */
+    pub fn get_process_monitor_job(
+        &mut self,
+        schedule: &str,
+    ) -> Result<Job, ApplicationError> {
+        info!("Creating Process monitor: {}", &self.name);
+        let process_monitor = self.clone();
+        let job_result = Job::new_async(schedule, move |_uuid, _locked| {
+            let process_monitor = process_monitor.clone();
+            Box::pin(async move {
+                let _ = process_monitor.clone().check().await.map_err(|err| error!("Error checking process monitor: {err:?}"));
+            })              
+        });        
+        match job_result {
+            Ok(job) => Ok(job),
+            Err(err) => Err(ApplicationError::new(
+                format!("Could not create job: {err}").as_str(),
+            )),
+        }
+    }
+
+    /**
+     * Check the applications.
+     * 
+     * Returns: The result of the check.
+     * 
+     * # Errors
+     * - If there is an error checking the application.
+     * 
+     */
+    pub async fn check(&mut self) -> Result<(), ApplicationError> {
+        let mut statuses: Vec<Status> = Vec::new();
+        for app_name in &self.application_names {
+            let new_statuses = self.check_application(app_name).await?;
+            statuses.extend(new_statuses);
+        }
+        let new_status = Status::get_max_status(statuses);
+        self.set_status(&new_status).await;
+        Ok(())
+    }    
+
+    /** 
+     * Check the application.
+     * 
+     * `app_name`: The application name.
+     * 
+     * Returns: The statuses of the checks.
+     * 
+     * # Errors
+     * - If there is an error reading the cmdlines.
+     * 
+     */
+    async fn check_application(&self, app_name: &str) -> Result<Vec<Status>, ApplicationError> {
+        debug!("Checking application: {app_name:?}");
+        let cmdlines_result = CmdLine::read_by_application(app_name);
+        match cmdlines_result {
+            Ok(cmdlines) => { 
+                Ok(self.check_processes(app_name, &cmdlines).await)
+            },
+            Err(err) => {
+                Err(ApplicationError::new(
+                    format!("Error reading cmdlines for application: {app_name:?}, err: {err:?}").as_str(),
+                ))
+            }
+        }
+    }
+
+    /**
+     * Check the processes.
+     * 
+     * `app_name`: The application name.
+     * `cmdlines`: The command lines.
+     * 
+     * Returns: The statuses of the checks.
+     * 
+     */
+    async fn check_processes(&self, app_name: &str, cmdlines: &Vec<CmdLine>) -> Vec<Status> {
+        debug!("Checking processes: {cmdlines:?}");
+        let mut statuses = Vec::new();
+        for cmdline in cmdlines {
+            statuses.push(self.check_process(app_name, cmdline).await);
+        };
+        statuses
+    }
+
+    /**
+     * Check the process.
+     * 
+     * `app_name`: The application name.
+     * `cmdline`: The command line.
+     *  
+     * Returns: The status of the check.
+     */
+    async fn check_process(&self, app_name: &str, cmdline: &CmdLine) -> Status {
+        debug!("Checking process: {cmdline:?}");
+        let statm = Statm::get_statm(cmdline.pid);
+        if let Ok(statm) = statm {
+            self.store_statm_values(app_name, cmdline, &statm).await;
+            self.check_max(&statm)
+        } else {
+            info!("Error getting statm for process, this could because the process no longer exist: {cmdline:?}");
+            Status::Ok
+        }
+    }
+
+    /**
+     * Check the max memory usage.
+     * 
+     * `statm`: The statm values.
+     * 
+     * Returns: The status of the check.
+     */
+    fn check_max(&self, statm: &Statm) -> Status {        
+        if let Some(max_mem_usage) = self.max_mem_usage {
+            if statm.size > self.max_mem_usage {
+                return Status::Error { message: format!("Process memory usage is over the limit: {:?} > {max_mem_usage:?}", statm.size)};
+            }
+        }
+        Status::Ok
+    }
+    
+    /**
+     * Store the statm values.
+     * 
+     * `app_name`: The application name.
+     * `cmdline`: The command line.
+     * `statm`: The statm values.
+     */
+    async fn store_statm_values(&self, app_name: &str, cmdline: &CmdLine, statm: &Statm) {
+        if self.store_current_statm {
+            self.store_current_statm_values(app_name, cmdline, statm).await;
+        }
+    }
+
+    /**
+     * Store the current statm values.
+     * 
+     * `app_name`: The application name.
+     * `cmdline`: The command line.
+     * `statm`: The statm values.
+     * 
+     * Returns: The result of storing the statm values.
+     * 
+     */
+    async fn store_current_statm_values(&self, app_name: &str, cmdline: &CmdLine, statm: &Statm) {
+        if let Some(database_service) = &*self.database_service {
+            let store_result: Result<(), ApplicationError> = database_service.store_statm_values(app_name, &cmdline.pid, statm).await;
+            match store_result {
+                Ok(()) => {
+                    info!("Stored statm values for process: {cmdline:?}");
+                }
+                Err(err) => {
+                    error!("Error storing statm values for process: {cmdline:?}, err: {err:?}");
+                }
+            }
+        }
+    }
+
+}
+
+/**
+ * Implement the `Monitor` trait for `MemoryinfoMonitor`.
+ */
+impl super::Monitor for ProcessMonitor {
+    /**
+     * Get the name of the monitor.
+     *
+     * Returns: The name of the monitor.
+     */
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /**
+     * Get the status of the monitor.
+     *
+     * Returns: The status of the monitor.
+     */
+    fn get_status(&self) -> Arc<Mutex<HashMap<String, MonitorStatus>>> {
+        self.status.clone()
+    }
+
+    /**
+     * Get the database service.
+     *
+     * Returns: The database service.
+     */
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
+        self.database_service.clone()
+    }
+
+    /**
+     * Get the database store level.
+     *
+     * Returns: The database store level.
+     */
+    fn get_database_store_level(&self) -> DatabaseStoreLevel {
+        self.database_store_level.clone()
+    }
+     
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_get_monitor_job() {
+        let mut process_monitor = ProcessMonitor::new(
+            "test_monitor",
+            &vec!["test_app".to_string()],
+            Some(100),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+            false
+        );
+        let job_result = process_monitor.get_process_monitor_job("* * * * * *");
+        assert!(job_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_check() {
+        let mut process_monitor = ProcessMonitor::new(
+            "test_monitor",
+            &vec!["test_app".to_string()],
+            Some(100),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+            false
+        );
+        let check_result = process_monitor.check().await;
+        assert!(check_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_check_systemd_status_not_ok() {
+        let mut process_monitor = ProcessMonitor::new(
+            "systemd monitor",
+            &vec!["/sbin/init".to_string()],
+            Some(0),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+            false
+        );
+        let check_result = process_monitor.check().await;
+        assert!(check_result.is_ok());
+        assert!(process_monitor.get_status().lock().unwrap().get("systemd monitor").unwrap().status != Status::Ok);
+    }
+
+    #[tokio::test]
+    async fn test_check_systemd_status_ok() {
+        let mut process_monitor = ProcessMonitor::new(
+            "systemd monitor",
+            &vec!["/sbin/init".to_string()],
+            Some(1000000),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+            false
+        );
+        let check_result = process_monitor.check().await;
+        assert!(check_result.is_ok());
+        assert!(process_monitor.get_status().lock().unwrap().get("systemd monitor").unwrap().status == Status::Ok);
+    }    
+
+}

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -5,7 +5,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{configuration::MonitoringConfig, ApplicationError, MonitorStatus};
 use crate::services::DbService;
-use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, MeminfoMonitor, SystemctlMonitor, TcpMonitor, DatabaseMonitor};
+use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, MeminfoMonitor, SystemctlMonitor, TcpMonitor, DatabaseMonitor, ProcessMonitor};
 
 /**
  * Scheduling Service.
@@ -215,6 +215,12 @@ impl SchedulingService {
                     &monitor.store,
                 );
                 let job = database_monitor.get_database_monitor_job(monitor.schedule.as_str())?;
+                self.add_job(scheduler, job).await
+            },
+            crate::common::MonitorType::Process { application_names, max_mem_usage, store_values 
+            } => {
+                let mut process_monitor = ProcessMonitor::new(&monitor.name, &application_names, max_mem_usage, &self.status, &self.database_service.clone(), &monitor.store, store_values);
+                let job = process_monitor.get_process_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
         }?;   

--- a/monitoring-agent-lib/src/proc/mod.rs
+++ b/monitoring-agent-lib/src/proc/mod.rs
@@ -6,8 +6,14 @@ pub mod meminfo;
 pub mod loadavg;
 /// Structure and methods to read and parse /proc/*/status 
 pub mod process;
+/// Memory use of a process
+pub mod statm;
+/// Structure and methods to read and parse /proc/*/cmdline
+pub mod cmdline;
 
 pub use crate::proc::cpuinfo::ProcsCpuinfo;
 pub use crate::proc::meminfo::ProcsMeminfo;
 pub use crate::proc::loadavg::ProcsLoadavg;
 pub use crate::proc::process::ProcsProcess;
+pub use crate::proc::statm::Statm;
+pub use crate::proc::cmdline::CmdLine;

--- a/monitoring-agent-lib/src/proc/statm.rs
+++ b/monitoring-agent-lib/src/proc/statm.rs
@@ -11,19 +11,19 @@ use crate::common::CommonLibError;
 #[derive(Debug, Clone)]
 pub struct Statm {
     /// Total program size (pages)
-    size: Option<u32>,
+    pub size: Option<u32>,
     /// Size of memory portions (pages)
-    resident: Option<u32>,
+    pub resident: Option<u32>,
     /// Number of pages that are shared
-    share: Option<u32>,
+    pub share: Option<u32>,
     /// Number of pages that are ‘code’
-    trs: Option<u32>,
+    pub trs: Option<u32>,
     /// Number of pages of data/stack
-    drs: Option<u32>,
+    pub drs: Option<u32>,
     /// Number of pages of library
-    lrs: Option<u32>,
+    pub lrs: Option<u32>,
     /// Number of dirty pages
-    dt: Option<u32>
+    pub dt: Option<u32>
 }
 
 impl Statm {


### PR DESCRIPTION
Implements a process monitor that can be configured to monitor a processes by commandline. It will store the /proc/<pid>/statm values in the database. Will also check if the process is higher than the configured threshold and will report error if it is.

Breaking changes: None

Resolves: #113