### PR TITLE
feat: Issue-115: Implement statm api

### DIFF
--- a/monitoring-agent-daemon/src/api/mod.rs
+++ b/monitoring-agent-daemon/src/api/mod.rs
@@ -7,6 +7,8 @@
  * `cpuinfo`: The cpu information API.
  * `loadavg`: The load average API.
  * `process`: The process API.
+ * `monitor`: The monitor API.
+ * `statm`: The statm API.
  */
 mod meminfo;
 mod state;
@@ -19,7 +21,7 @@ mod monitor;
 pub use crate::api::meminfo::get_current_meminfo;
 pub use crate::api::cpuinfo::get_current_cpuinfo;
 pub use crate::api::loadavg::get_current_loadavg;
-pub use crate::api::process::{get_processes, get_process, get_threads};
+pub use crate::api::process::{get_processes, get_process, get_threads, get_current_statm};
 pub use crate::api::monitor::get_monitor_status;
 
 #[allow(clippy::module_name_repetitions)]

--- a/monitoring-agent-daemon/src/api/process.rs
+++ b/monitoring-agent-daemon/src/api/process.rs
@@ -1,6 +1,6 @@
 use actix_web::{get, web, HttpResponse, Responder};
 
-use crate::api::StateApi;
+use crate::api::{response::StatmResponse, StateApi};
 
 use super::response::ProcessResponse;
 
@@ -50,6 +50,24 @@ pub async fn get_threads(state: web::Data<StateApi>, path: web::Path<u32>) -> im
     let procs = state.monitoring_service.get_process_threads(pid);    
     match procs {
         Ok(procs) => HttpResponse::Ok().json(ProcessResponse::from_processes(&procs)),
+        Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
+    }
+}
+
+/**
+ * Get current statm.
+ * 
+ * `state`: The state object.
+ * `path`: The path object.
+ * 
+ * Returns the current statm.
+ */
+#[get("/processes/{pid}/statm")]
+pub async fn get_current_statm(state: web::Data<StateApi>, path: web::Path<u32>) -> impl Responder {
+    let pid: u32 = path.into_inner();
+    let procs_statm = state.monitoring_service.get_current_statm(pid);
+    match procs_statm {
+        Ok(procs_statm) => HttpResponse::Ok().json(StatmResponse::from_current_statm(&procs_statm)),
         Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
     }
 }

--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -478,6 +478,7 @@ impl MonitorStatusResponse {
  * * Number of pages of library
  * * Number of dirty pages
  */
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatmResponse {
     /// Total program size (pages)

--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use monitoring_agent_lib::proc::{process::ProcessState, ProcsCpuinfo, ProcsLoadavg, ProcsMeminfo, ProcsProcess};
+use monitoring_agent_lib::proc::{process::ProcessState, ProcsCpuinfo, ProcsLoadavg, ProcsMeminfo, ProcsProcess, ProcsStatm};
 use serde::{Deserialize, Serialize};
 
 use crate::common::{MonitorStatus, Status};
@@ -464,6 +464,69 @@ impl MonitorStatusResponse {
     }
 }
 
+/**
+ * The `StatmResponse` struct represents the response of the statm endpoint.
+ * 
+ * The statm file provides information about memory usage, measured in pages.
+ * 
+ * The statm file contains the following columns:
+ * * Total program size (pages)
+ * * Size of memory portions (pages)
+ * * Number of pages that are shared
+ * * Number of pages that are ‘code’
+ * * Number of pages of data/stack
+ * * Number of pages of library
+ * * Number of dirty pages
+ */
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatmResponse {
+    /// Total program size (pages)
+    #[serde(skip_serializing_if = "Option::is_none", rename = "totalSize")]    
+    pub size: Option<u32>,
+    /// Size of memory portions (pages)
+    #[serde(skip_serializing_if = "Option::is_none", rename = "residentSize")]         
+    pub resident: Option<u32>,
+    /// Number of pages that are shared
+    #[serde(skip_serializing_if = "Option::is_none", rename = "sharedSize")]              
+    pub share: Option<u32>,
+    /// Number of pages that are ‘code’
+    #[serde(skip_serializing_if = "Option::is_none", rename = "trsSize")]             
+    pub trs: Option<u32>,
+    /// Number of pages of data/stack
+    #[serde(skip_serializing_if = "Option::is_none", rename = "drsSize")]             
+    pub drs: Option<u32>,
+    /// Number of pages of library
+    #[serde(skip_serializing_if = "Option::is_none", rename = "lrsSize")]             
+    pub lrs: Option<u32>,
+    /// Number of dirty pages
+    #[serde(skip_serializing_if = "Option::is_none", rename = "dtSize")]             
+    pub dt: Option<u32>
+}
+
+impl StatmResponse {
+
+    /**
+     * Create a new `StatmResponse`.
+     * 
+     * `procs_statm`: The procs statm.
+     * 
+     * Returns a new `StatmResponse`.
+     */
+    pub fn from_current_statm(
+        procs_statm :&ProcsStatm
+    ) -> StatmResponse {
+        StatmResponse {
+            size: procs_statm.size,
+            resident: procs_statm.resident,
+            share: procs_statm.share,
+            trs: procs_statm.trs,
+            drs: procs_statm.drs,
+            lrs: procs_statm.lrs,
+            dt: procs_statm.dt
+        }
+    }   
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -674,4 +737,46 @@ mod test {
         assert_eq!(MonitorStatusResponse::from_status(&Status::Unknown), MonitorStatusResponse::Unknown);
         assert_eq!(MonitorStatusResponse::from_status(&Status::Error { message: "error".to_string() }), MonitorStatusResponse::Error);
     }
+
+    #[test]
+    fn test_from_statm() {
+        let procs_statm = ProcsStatm {
+            size: Some(1),
+            resident: Some(2),
+            share: Some(3),
+            trs: Some(4),
+            drs: Some(5),
+            lrs: Some(6),
+            dt: Some(7),
+        };
+        let statm_response = StatmResponse::from_current_statm(&procs_statm);
+        assert_eq!(statm_response.size, Some(1));
+        assert_eq!(statm_response.resident, Some(2));
+        assert_eq!(statm_response.share, Some(3));
+        assert_eq!(statm_response.trs, Some(4));
+        assert_eq!(statm_response.drs, Some(5));
+        assert_eq!(statm_response.lrs, Some(6));
+        assert_eq!(statm_response.dt, Some(7));        
+    }
+
+    #[test]
+    fn test_from_statm_none() {
+        let procs_statm = ProcsStatm {
+            size: None,
+            resident: None,
+            share: None,
+            trs: None,
+            drs: None,
+            lrs: None,
+            dt: None,
+        };
+        let statm_response = StatmResponse::from_current_statm(&procs_statm);
+        assert_eq!(statm_response.size, None);
+        assert_eq!(statm_response.resident, None);
+        assert_eq!(statm_response.share, None);
+        assert_eq!(statm_response.trs, None);
+        assert_eq!(statm_response.drs, None);
+        assert_eq!(statm_response.lrs, None);
+        assert_eq!(statm_response.dt, None);        
+    }    
 }

--- a/monitoring-agent-daemon/src/common/applicationerror.rs
+++ b/monitoring-agent-daemon/src/common/applicationerror.rs
@@ -4,6 +4,7 @@
 #[derive(Debug)]
 pub struct ApplicationError {
     /// The error message.
+    #[allow(dead_code)]
     pub message: String,
 }
 
@@ -20,7 +21,7 @@ impl ApplicationError {
             message: message.to_string(),
         }
     }
-
+    #[allow(dead_code)]
     pub fn get_message(&self) -> String {
         self.message.clone()
     }

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -134,6 +134,7 @@ async fn start_application(monitoring_config: &MonitoringConfig, args: &Applicat
             .service(api::get_process)
             .service(api::get_threads)
             .service(api::get_monitor_status)
+            .service(api::get_current_statm)
     })
     .bind((ip, port))?
     .run()

--- a/monitoring-agent-daemon/src/services/monitoringservice.rs
+++ b/monitoring-agent-daemon/src/services/monitoringservice.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use log::error;
-use monitoring_agent_lib::proc::{ProcsCpuinfo, ProcsLoadavg, ProcsMeminfo, ProcsProcess};
+use monitoring_agent_lib::proc::{ProcsCpuinfo, ProcsLoadavg, ProcsMeminfo, ProcsProcess, ProcsStatm};
 
 use crate::common::{ApplicationError, MonitorStatus};
 
@@ -171,6 +171,27 @@ impl MonitoringService {
             Err(err) => {
                 error!("Error getting monitor statuses: {:?}", err);
                 Vec::new()
+            }
+        }
+    }
+
+    /**
+     * Get the current statm.
+     * 
+     * `pid`: The process id.
+     * 
+     * result: The result of getting the current statm.
+     * 
+     * # Errors
+     * - If there is an error getting the statm.
+     */
+    pub fn get_current_statm(&self, pid: u32) -> Result<ProcsStatm, ApplicationError> {
+        let statm = ProcsStatm::get_statm(pid);
+        match statm {
+            Ok(statm) => Ok(statm),
+            Err(err) => {
+                error!("Error: {}", err.message);
+                Err(ApplicationError::new("Error getting statm"))                
             }
         }
     }

--- a/monitoring-agent-daemon/src/services/monitoringservice.rs
+++ b/monitoring-agent-daemon/src/services/monitoringservice.rs
@@ -185,6 +185,7 @@ impl MonitoringService {
      * # Errors
      * - If there is an error getting the statm.
      */
+    #[allow(clippy::unused_self)]
     pub fn get_current_statm(&self, pid: u32) -> Result<ProcsStatm, ApplicationError> {
         let statm = ProcsStatm::get_statm(pid);
         match statm {

--- a/monitoring-agent-lib/src/proc/mod.rs
+++ b/monitoring-agent-lib/src/proc/mod.rs
@@ -15,5 +15,5 @@ pub use crate::proc::cpuinfo::ProcsCpuinfo;
 pub use crate::proc::meminfo::ProcsMeminfo;
 pub use crate::proc::loadavg::ProcsLoadavg;
 pub use crate::proc::process::ProcsProcess;
-pub use crate::proc::statm::Statm;
-pub use crate::proc::cmdline::CmdLine;
+pub use crate::proc::statm::ProcsStatm;
+pub use crate::proc::cmdline::ProcsCmdLine;

--- a/monitoring-agent-lib/src/proc/statm.rs
+++ b/monitoring-agent-lib/src/proc/statm.rs
@@ -7,7 +7,7 @@ use crate::common::CommonLibError;
  * 
  * TODO: Add more detailed text.
  */
-#[warn(dead_code)]
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
 pub struct ProcsStatm {
     /// Total program size (pages)

--- a/monitoring-agent-lib/src/proc/statm.rs
+++ b/monitoring-agent-lib/src/proc/statm.rs
@@ -9,7 +9,7 @@ use crate::common::CommonLibError;
  */
 #[warn(dead_code)]
 #[derive(Debug, Clone)]
-pub struct Statm {
+pub struct ProcsStatm {
     /// Total program size (pages)
     pub size: Option<u32>,
     /// Size of memory portions (pages)
@@ -26,7 +26,7 @@ pub struct Statm {
     pub dt: Option<u32>
 }
 
-impl Statm {
+impl ProcsStatm {
     /**
      * Create a new `Statm`.
      * 
@@ -48,8 +48,8 @@ impl Statm {
         drs: &Option<u32>,
         lrs: &Option<u32>,
         dt: &Option<u32>
-    ) -> Statm {
-        Statm {
+    ) -> ProcsStatm {
+        ProcsStatm {
             size: *size,
             resident: *resident,
             share: *share,
@@ -76,11 +76,11 @@ impl Statm {
      *  - If there is an error parsing the data from the meminfo file.
      */
     #[tracing::instrument(level = "debug")]
-    pub fn get_statm(pid: u32) -> Result<Statm, CommonLibError> {
+    pub fn get_statm(pid: u32) -> Result<ProcsStatm, CommonLibError> {
         let statm_file = File::open("/proc/".to_string() + pid.to_string().as_str() + "/statm").map_err(|err| {
             CommonLibError::new(format!("Error reading statm file: {err:?}").as_str())
         })?;
-        Statm::read_statm(statm_file)
+        ProcsStatm::read_statm(statm_file)
     }
     
     /**
@@ -94,13 +94,13 @@ impl Statm {
      * # Errors
      * - If there is an error reading the statm file.
      */
-    fn read_statm(file: File) -> Result<Statm, CommonLibError> {
+    fn read_statm(file: File) -> Result<ProcsStatm, CommonLibError> {
         let mut reader = BufReader::new(file);
         let mut buffer = String::new();
         let _ =  reader.read_line(&mut buffer).map_err(|err| {
             CommonLibError::new(format!("Error reading statm: {err:?}").as_str())
         })?;
-        Ok(Statm::handle_statm_file(buffer.as_str()))        
+        Ok(ProcsStatm::handle_statm_file(buffer.as_str()))        
     }
 
     /**
@@ -110,7 +110,7 @@ impl Statm {
      * 
      * Returns the statm data or an error.
      */
-    fn handle_statm_file(buffer: &str) -> Statm {
+    fn handle_statm_file(buffer: &str) -> ProcsStatm {
         let cols = buffer.split_whitespace().collect::<Vec<&str>>();
         let size = cols[0].parse::<u32>().ok();
         let resident = cols[1].parse::<u32>().ok();
@@ -119,7 +119,7 @@ impl Statm {
         let lrs: Option<u32> = cols[4].parse::<u32>().ok();
         let drs = cols[5].parse::<u32>().ok();
         let dt = cols[6].parse::<u32>().ok();
-        Statm::new(&size, &resident, &share, &trs, &drs, &lrs, &dt)
+        ProcsStatm::new(&size, &resident, &share, &trs, &drs, &lrs, &dt)
     }
 
 }
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_handle_statm_from_buffer1() {
         let buffer = "5805 3442 2354 11 0 1082 0";
-        let statm = Statm::handle_statm_file(buffer);
+        let statm = ProcsStatm::handle_statm_file(buffer);
         assert_eq!(statm.size, Some(5805));
         assert_eq!(statm.resident, Some(3442));
         assert_eq!(statm.share, Some(2354));
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn test_handle_statm_buffer2() {
         let buffer = "494524 21506 2214 1471 0 59164 0";
-        let statm = Statm::handle_statm_file(buffer);
+        let statm = ProcsStatm::handle_statm_file(buffer);
         assert_eq!(statm.size, Some(494524));
         assert_eq!(statm.resident, Some(21506));
         assert_eq!(statm.share, Some(2214));
@@ -156,13 +156,13 @@ mod tests {
 
     #[test]
     fn test_handle_statm_pid_1() {
-        let statm = Statm::get_statm(1);
+        let statm = ProcsStatm::get_statm(1);
         assert!(statm.is_ok());
     }  
 
     #[test]
     fn test_handle_statm_pid_0() {
-        let statm = Statm::get_statm(0);
+        let statm = ProcsStatm::get_statm(0);
         assert!(statm.is_err());
     }    
 }


### PR DESCRIPTION
Implements the statm api for the monitoring agent daemon. This api will
return the memory usage of the process.
The following fields are returned.
    - totalSize: Total program size (pages)
    - residentSize: Size of memory portions (pages)
    - shareSize: Number of pages that are shared
    - trsSize: Number of pages that are ‘code’
    - drsSize: Number of pages of data/stack
    - lrsSize: Number of pages of library
    - dtSize: Number of dirty pages
    
Also updates the names of the Statm and CmlLine structs to ProcsStatm
and ProcsCmdLine respectively.
    
Breaking changes: None

Resolves: #115
