### PR TITLE
feat:Issue-143:Add message when check all fails/succeeds

### DIFF
--- a/monitoring-agent-ui/src/components/Settings.vue
+++ b/monitoring-agent-ui/src/components/Settings.vue
@@ -67,14 +67,20 @@ export default {
     },
     // Check all URLs
     async checkAll() {      
+      let failed = [];
       for (let url of this.urls) {
         this.ping(url).then(success => {
           if (!success) {
-            alert('Ping failed for: ' + url);
+            failed.push(url);            
           }
         });
-      }      
+      } 
+      if (failed.length > 0) {
+        alert('Ping failed for: ' + failed.join(', '));
+      } else {
+        alert('Ping successful for all URLs');     
     }
+  }
   }
 }
 </script>


### PR DESCRIPTION
Currently the user has no feedback when the check all button succeeds and one message for each failure. This commit adds a message to the user when the check all button fails or succeeds.

Breaking changes: None

Resolves: #143