### PR TITLE
feat:Issue-167:Add description to monitors

### DIFF
--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -363,6 +363,9 @@ pub struct MonitorResponse {
     /// Name of the monitor.
     #[serde(rename = "name")]
     name: String,
+    /// Description of the monitor.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "description")]
+    description: Option<String>,
     /// The status of the monitor.
     #[serde(rename = "status")]
     status: MonitorStatusResponse,
@@ -390,6 +393,7 @@ impl MonitorResponse {
      */
     pub fn new(
         name: String,
+        description: Option<String>,
         status: MonitorStatusResponse,
         last_successful_time: Option<DateTime<Utc>>,
         last_error: Option<String>,
@@ -397,6 +401,7 @@ impl MonitorResponse {
     ) -> MonitorResponse {
         MonitorResponse {
             name,
+            description,
             status,
             last_successful_time,
             last_error,
@@ -415,6 +420,7 @@ impl MonitorResponse {
     pub fn from_monitor_status_message(monitor_status: &MonitorStatus) -> MonitorResponse {
         MonitorResponse::new(
             monitor_status.name.clone(),
+            monitor_status.description.clone(),
             MonitorStatusResponse::from_status(&monitor_status.status),
             monitor_status.last_successful_time,
             monitor_status.last_error.clone(),
@@ -857,6 +863,7 @@ mod test {
     fn test_from_monitor_status_message() {
         let monitor_status = MonitorStatus {
             name: "name".to_string(),
+            description: None,
             status: Status::Ok,
             last_successful_time: Some(Utc::now()),
             last_error: Some("error".to_string()),
@@ -872,7 +879,7 @@ mod test {
 
     #[test]
     fn test_new_moniorresponse() {
-        let monitor_response = MonitorResponse::new("name".to_string(), MonitorStatusResponse::Ok, Some(Utc::now()), Some("error".to_string()), Some(Utc::now()));
+        let monitor_response = MonitorResponse::new("name".to_string(), None, MonitorStatusResponse::Ok, Some(Utc::now()), Some("error".to_string()), Some(Utc::now()));
         assert_eq!(monitor_response.name, "name".to_string());
         assert_eq!(monitor_response.status, MonitorStatusResponse::Ok);
         assert_eq!(monitor_response.last_successful_time.is_some(), true);
@@ -884,6 +891,7 @@ mod test {
     fn test_from_monitor_status_messages() {
         let monitor_status = vec![MonitorStatus {
             name: "name".to_string(),
+            description: None,
             status: Status::Ok,
             last_successful_time: Some(Utc::now()),
             last_error: Some("error".to_string()),

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -122,6 +122,9 @@ pub struct Monitor {
     /// The name of the monitor.
     #[serde(rename = "name")]
     pub name: String,
+    /// The description of the monitor.
+    #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// The schedule of the monitor.
     #[serde(rename = "schedule")]
     pub schedule: String,

--- a/monitoring-agent-daemon/src/common/monitorstatus.rs
+++ b/monitoring-agent-daemon/src/common/monitorstatus.rs
@@ -4,6 +4,8 @@ use chrono::{DateTime, Utc};
  * `MonitorStatus` struct
  * 
  *  This struct is used to represent the status of a monitor in the service modules. It contains the following fields:
+ * - `name`: The name of the monitor
+ * - `description`: The description of the monitor
  * - `status`: The status of the monitor
  * - `last_successful_time`: The last time the monitor was successful
  * - `last_error`: The last error message
@@ -14,6 +16,8 @@ use chrono::{DateTime, Utc};
 pub struct MonitorStatus {
     /// The name of the monitor.
     pub name: String,
+    /// The description of the monitor.
+    pub description: Option<String>,    
     /// The status of the monitor.
     pub status: Status,
     /// The last time the monitor was successful.
@@ -28,12 +32,15 @@ impl MonitorStatus {
     /**
      * Create a new `MonitorStatus`.
      *
+     * `name`: The name of the monitor.
+     * `description`: The description of the monitor.
      * `status`: The status of the monitor.
      *
      */
-    pub fn new(name: String, status: Status) -> MonitorStatus {
+    pub fn new(name: &str, description: &Option<String>, status: Status) -> MonitorStatus {
         MonitorStatus {
-            name,
+            name: name.to_string(),
+            description: description.clone(),
             status,
             last_successful_time: None,
             last_error: None,
@@ -110,7 +117,7 @@ mod test {
     fn test_monitorstatus_new() {
         let name = "test_monitor";
         let status = Status::Ok;
-        let monitorstatus = MonitorStatus::new(name.to_string(), status.clone());
+        let monitorstatus = MonitorStatus::new(name,  &None, status.clone());
         assert_eq!(monitorstatus.name, name);
         assert_eq!(monitorstatus.status, status);
         assert_eq!(monitorstatus.last_successful_time, None);
@@ -122,7 +129,7 @@ mod test {
     fn test_monitorstatus_set_status() {
         let name = "test_monitor";
         let status = Status::Ok;
-        let mut monitorstatus = MonitorStatus::new(name.to_string(), status.clone());
+        let mut monitorstatus = MonitorStatus::new(name, &None, status.clone());
         monitorstatus.set_status(&status);
         assert_eq!(monitorstatus.status, status);
         assert!(monitorstatus.last_successful_time.is_some());

--- a/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/commandmonitor.rs
@@ -56,6 +56,7 @@ impl CommandMonitor {
      * Returns: A new command monitor.
      * 
      */
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,
         description: &Option<String>,

--- a/monitoring-agent-daemon/src/services/monitors/common.rs
+++ b/monitoring-agent-daemon/src/services/monitors/common.rs
@@ -109,7 +109,7 @@ mod test {
     fn test_monitorstatus_new() {
         let name = "test_monitor";
         let status = Status::Ok;
-        let monitorstatus = MonitorStatus::new(name.to_string(), status.clone());
+        let monitorstatus = MonitorStatus::new(name, &None, status.clone());
         assert_eq!(monitorstatus.name, name);
         assert_eq!(monitorstatus.status, status);
         assert_eq!(monitorstatus.last_successful_time, None);
@@ -121,7 +121,7 @@ mod test {
     fn test_monitorstatus_set_status() {
         let name = "test_monitor";
         let status = Status::Ok;
-        let mut monitorstatus = MonitorStatus::new(name.to_string(), status.clone());
+        let mut monitorstatus = MonitorStatus::new(name, &None, status.clone());
         monitorstatus.set_status(&status);
         assert_eq!(monitorstatus.status, status);
         assert!(monitorstatus.last_successful_time.is_some());

--- a/monitoring-agent-daemon/src/services/monitors/databasemonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/databasemonitor.rs
@@ -11,6 +11,7 @@ use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, Monito
  * This struct represents a database monitor.
  * 
  * `name`: The name of the monitor.
+ * `description`: The description of the monitor.
  * `query_max_time`: The max query time.
  * `status`: The status of the monitor.
  * `database_service`: The database service.
@@ -19,7 +20,7 @@ use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, Monito
 #[derive(Debug, Clone)]
 pub struct DatabaseMonitor {
     /// The name of the monitor.
-    pub name: String,
+    pub name: String, 
     /// Max query time.
     pub query_max_time: Option<u32>,
     /// The current status of the monitor.
@@ -44,6 +45,7 @@ impl DatabaseMonitor {
      */
     pub fn new(
         name: &str,
+        description: &Option<String>,
         query_max_time: Option<u32>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
         database_service: &Arc<Option<DbService>>,
@@ -53,7 +55,7 @@ impl DatabaseMonitor {
         let status_lock = status.lock();
         match status_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(),Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name, description, Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating command monitor: {:?}", err);
@@ -184,7 +186,7 @@ mod test {
         let status = Arc::new(Mutex::new(HashMap::new()));
         let database_service = Arc::new(None);
         let database_store_level = DatabaseStoreLevel::None;
-        let database_monitor = DatabaseMonitor::new(name, None, &status, &database_service, &database_store_level);
+        let database_monitor = DatabaseMonitor::new(name, &None, None, &status, &database_service, &database_store_level);
         assert_eq!(database_monitor.name, name);
     }
 
@@ -194,7 +196,7 @@ mod test {
         let status = Arc::new(Mutex::new(HashMap::new()));
         let database_service = Arc::new(None);
         let database_store_level = DatabaseStoreLevel::None;
-        let mut database_monitor = DatabaseMonitor::new(name, None, &status, &database_service, &database_store_level);
+        let mut database_monitor = DatabaseMonitor::new(name, &None, None, &status, &database_service, &database_store_level);
         let job = database_monitor.get_database_monitor_job("* * * * * *");
         assert!(job.is_ok());
     }
@@ -205,7 +207,7 @@ mod test {
         let status = Arc::new(Mutex::new(HashMap::new()));
         let database_service = Arc::new(None);
         let database_store_level = DatabaseStoreLevel::None;
-        let mut database_monitor = DatabaseMonitor::new(name, None, &status, &database_service, &database_store_level);
+        let mut database_monitor = DatabaseMonitor::new(name, &None, None, &status, &database_service, &database_store_level);
         let check = database_monitor.check().await;
         assert_eq!(check, ());
     }
@@ -216,7 +218,7 @@ mod test {
         let status = Arc::new(Mutex::new(HashMap::new()));
         let database_service = Arc::new(None);
         let database_store_level = DatabaseStoreLevel::None;
-        let database_monitor = DatabaseMonitor::new(name, None, &status, &database_service, &database_store_level);
+        let database_monitor = DatabaseMonitor::new(name, &None, None, &status, &database_service, &database_store_level);
         assert_eq!(database_monitor.get_name(), name);
     }
 
@@ -226,7 +228,7 @@ mod test {
         let status = Arc::new(Mutex::new(HashMap::new()));
         let database_service = Arc::new(None);
         let database_store_level = DatabaseStoreLevel::None;
-        let database_monitor = DatabaseMonitor::new(name, None, &status, &database_service, &database_store_level);
+        let database_monitor = DatabaseMonitor::new(name, &None, None, &status, &database_service, &database_store_level);
         assert_eq!(database_monitor.get_status().lock().unwrap().get("test").unwrap().status, Status::Unknown);
     }
 }

--- a/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/httpmonitor.rs
@@ -24,6 +24,7 @@ use crate::services::DbService;
  * This struct represents an HTTP monitor.
  *
  * name: The name of the monitor.
+ * description: The description of the monitor.
  * url: The URL to monitor.
  * method: The HTTP method to use.
  * body: The body of the request.
@@ -33,7 +34,7 @@ use crate::services::DbService;
 #[derive(Debug, Clone)]
 pub struct HttpMonitor {
     /// The name of the monitor.
-    pub name: String,
+    pub name: String,   
     /// The URL to monitor.
     pub url: String,
     /// The HTTP method to use.
@@ -80,6 +81,7 @@ impl HttpMonitor {
         body: &Option<String>,
         headers: &Option<HashMap<String, String>>,
         name: &str,
+        description: &Option<String>,
         use_builtin_root_certs: bool,
         accept_invalid_certs: bool,
         tls_info: bool,
@@ -140,7 +142,7 @@ impl HttpMonitor {
         let monitor_lock = status.lock();
         match monitor_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name, description, Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating HTTP monitor: {:?}", err);
@@ -495,6 +497,7 @@ mod test {
             &None,
             &None,
             "localhost",
+            &None,
             true,
             true,
             false,
@@ -539,6 +542,7 @@ mod test {
             &None,
             &None,
             "Google",
+            &None,
             true,
             true,
             false,
@@ -567,6 +571,7 @@ mod test {
             &None,
             &None,
             "Google",
+            &None,
             true,
             true,
             false,

--- a/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
@@ -7,7 +7,22 @@ use tokio_cron_scheduler::Job;
 use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, DbService};
 
 use super::Monitor;
-
+/**
+ * Load average monitor.
+ * 
+ * This struct represents a load average monitor.
+ * 
+ * `name`: The name of the monitor.
+ * `description`: The description of the monitor.
+ * `loadavg1min_max`: The max load average for 1 minute.
+ * `loadavg5min_max`: The max load average for 5 minutes.
+ * `loadavg15min_max`: The max load average for 10 minutes.
+ * `status`: The status of the monitor.
+ * `database_service`: The database service.
+ * `database_store_level`: The database store level.
+ * `store_current_loadavg`: Store the current load average.
+ * 
+ */
 #[derive(Debug, Clone)]
 pub struct LoadAvgMonitor {
     /// The name of the monitor.
@@ -49,6 +64,7 @@ impl LoadAvgMonitor {
     #[allow(clippy::similar_names)]    
     pub fn new(
         name: &str,
+        description: &Option<String>,
         loadavg1min_max: Option<f32>,
         loadavg5min_max: Option<f32>,
         loadavg15min_max: Option<f32>,
@@ -61,7 +77,7 @@ impl LoadAvgMonitor {
         let status_lock = status.lock();
         match status_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name, description, Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating loadavg monitor: {:?}", err);
@@ -299,6 +315,7 @@ mod test {
         // Test success. Loadaverage lower on all
         let mut monitor = super::LoadAvgMonitor::new(
             "test",
+            &None,
             Some(1.0),
             Some(2.0),
             Some(3.0),
@@ -334,6 +351,7 @@ mod test {
         // Test success. Loadaverage lower on all
         let mut monitor = super::LoadAvgMonitor::new(
             "test",
+            &None,
             Some(1.0),
             Some(2.0),
             Some(3.0),
@@ -369,6 +387,7 @@ mod test {
         // Test success. Loadaverage lower on all
         let mut monitor = super::LoadAvgMonitor::new(
             "test",
+            &None,
             Some(1.0),
             Some(2.0),
             Some(3.0),
@@ -404,6 +423,7 @@ mod test {
         // Test success. Loadaverage lower on all
         let mut monitor = super::LoadAvgMonitor::new(
             "test",
+            &None,
             Some(1.0),
             Some(2.0),
             Some(3.0),
@@ -434,6 +454,7 @@ mod test {
             Arc::new(Mutex::new(HashMap::new()));
         let mut monitor = LoadAvgMonitor::new(
             "test",
+            &None,
             Some(1.0),
             Some(2.0),
             Some(3.0),

--- a/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
@@ -8,10 +8,24 @@ use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, Monito
 
 use super::Monitor;
 
+/**
+ * Meminfo monitor.
+ * 
+ * This struct represents a meminfo monitor.
+ * 
+ * `name`: The name of the monitor.
+ * `description`: The description of the monitor.
+ * `max_percentage_mem`: The maximum percentage memory.
+ * `max_percentage_swap`: The maximum percentage swap.
+ * `status`: The status of the monitor.
+ * `database_service`: The database service.
+ * `database_store_level`: The database store level.
+ * `store_current_meminfo`: Store the current meminfo.
+ */
 #[derive(Debug, Clone)]
 pub struct MeminfoMonitor {
     /// The name of the monitor.
-    pub name: String,
+    pub name: String,   
     /// Minimum free percentage memory.
     pub max_percentage_mem: Option<f64>,
     /// Minimum free percentage swap memory.
@@ -46,6 +60,7 @@ impl MeminfoMonitor {
     #[allow(clippy::similar_names)]    
     pub fn new(
         name: &str,
+        description: &Option<String>,
         max_percentage_mem: Option<f64>,
         max_percentage_swap: Option<f64>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
@@ -57,7 +72,7 @@ impl MeminfoMonitor {
         let status_lock = status.lock();
         match status_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name, description, Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating meminfo monitor: {:?}", err);
@@ -255,6 +270,7 @@ mod test {
     async fn test_check() {
         let mut monitor = super::MeminfoMonitor::new(
             "test",
+            &None,
             Some(100.0),
             Some(100.0),
             &Arc::new(Mutex::new(HashMap::new())),
@@ -279,6 +295,7 @@ mod test {
         // Test success. Memory lower on all
         let mut monitor = super::MeminfoMonitor::new(
             "test",
+            &None,
             Some(80.0),
             Some(80.0),
             &Arc::new(Mutex::new(HashMap::new())),
@@ -314,6 +331,7 @@ mod test {
         // Test success. Memory lower on all
         let mut monitor = super::MeminfoMonitor::new(
             "test",
+            &None,
             Some(70.0),
             Some(15.0),
             &Arc::new(Mutex::new(HashMap::new())),
@@ -343,6 +361,7 @@ mod test {
             Arc::new(Mutex::new(HashMap::new()));
         let mut monitor = MeminfoMonitor::new(
             "test",
+            &None,
             Some(100.0),
             Some(100.0),
             &status,

--- a/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
@@ -10,6 +10,16 @@ use super::Monitor;
 
 /**
  * The `ProcessMonitor` struct represents a moniitor for checking processes.
+ * 
+ * `name`: The monitor name.
+ * `description`: The description of the monitor.
+ * `application_names`: The application names to monitor.
+ * `max_mem_usage`: The max memory usage.
+ * `status`: The status of the monitor.
+ * `database_service`: The database service.
+ * `database_store_level`: The database store level.
+ * `store_current_statm`: Store the current statm.
+ * 
  */
 #[derive(Debug, Clone)]
 pub struct ProcessMonitor {
@@ -45,6 +55,7 @@ impl ProcessMonitor {
      */
     pub fn new(
         name: &str,
+        description: &Option<String>,
         application_names: &[String],
         max_mem_usage: Option<u32>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
@@ -56,7 +67,7 @@ impl ProcessMonitor {
         let status_lock = status.lock();
         match status_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name, description, Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating systemctl monitor: {err:?}");
@@ -288,6 +299,7 @@ mod test {
     fn test_get_monitor_job() {
         let mut process_monitor = ProcessMonitor::new(
             "test_monitor",
+            &None,
             &vec!["test_app".to_string()],
             Some(100),
             &Arc::new(Mutex::new(HashMap::new())),
@@ -303,6 +315,7 @@ mod test {
     async fn test_check() {
         let mut process_monitor = ProcessMonitor::new(
             "test_monitor",
+            &None,
             &vec!["test_app".to_string()],
             Some(100),
             &Arc::new(Mutex::new(HashMap::new())),
@@ -318,6 +331,7 @@ mod test {
     async fn test_check_systemd_status_not_ok() {
         let mut process_monitor = ProcessMonitor::new(
             "systemd monitor",
+            &None,
             &vec!["/sbin/init".to_string()],
             Some(0),
             &Arc::new(Mutex::new(HashMap::new())),
@@ -334,6 +348,7 @@ mod test {
     async fn test_check_systemd_status_ok() {
         let mut process_monitor = ProcessMonitor::new(
             "systemd monitor",
+            &None,
             &vec!["/sbin/init".to_string()],
             Some(1000000),
             &Arc::new(Mutex::new(HashMap::new())),

--- a/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
@@ -53,6 +53,7 @@ impl ProcessMonitor {
      * 
      * Returns a new `ProcessMonitor`.
      */
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,
         description: &Option<String>,

--- a/monitoring-agent-daemon/src/services/monitors/systemctlmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/systemctlmonitor.rs
@@ -9,11 +9,23 @@ use super::Monitor;
 
 const SYSTEMD_ACTIVE_STATUS: &str = "active";
 
-
+/**
+ * Systemctl monitor.
+ * 
+ * This struct represents a systemctl monitor.
+ * 
+ * `name`: The name of the monitor.
+ * `description`: The description of the monitor.
+ * `status`: The status of the monitor.
+ * `database_service`: The database service.
+ * `database_store_level`: The database store level.
+ * `active`: The services to monitor.
+ * 
+ */
 #[derive(Debug, Clone)]
 pub struct SystemctlMonitor {
     /// The name of the monitor.
-    pub name: String,
+    pub name: String,   
     /// The status of the monitor.
     pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
@@ -37,6 +49,7 @@ impl SystemctlMonitor {
      */
     pub fn new(
         name: &str,
+        description: &Option<String>,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
         database_service: &Arc<Option<DbService>>,
         database_store_level: &DatabaseStoreLevel,
@@ -46,7 +59,7 @@ impl SystemctlMonitor {
         let status_lock = status.lock();
         match status_lock {
             Ok(mut lock) => {
-                lock.insert(name.to_string(), MonitorStatus::new(name.to_string(), Status::Unknown));
+                lock.insert(name.to_string(), MonitorStatus::new(name, description, Status::Unknown));
             }
             Err(err) => {
                 error!("Error creating systemctl monitor: {err:?}");
@@ -188,6 +201,7 @@ mod test {
         let active = vec![  ];
         let systemctl_monitor = SystemctlMonitor::new(
             "test",
+            &None,
             &status,
             &database_service,
             &database_store_level,
@@ -211,6 +225,7 @@ mod test {
         let active = vec![ "ssh".to_string() ];
         let systemctl_monitor = SystemctlMonitor::new(
             "test",
+            &None,
             &status,
             &database_service,
             &database_store_level,
@@ -232,6 +247,7 @@ mod test {
         let active = vec![ "uuidd".to_string() ];
         let systemctl_monitor = SystemctlMonitor::new(
             "test",
+            &None,
             &status,
             &database_service,
             &database_store_level,
@@ -248,6 +264,7 @@ mod test {
             Arc::new(Mutex::new(HashMap::new()));
         let mut monitor = SystemctlMonitor::new(
             "test",
+            &None,
             &status,
             &Arc::new(None),
             &DatabaseStoreLevel::None,

--- a/monitoring-agent-ui/src/components/Monitors.vue
+++ b/monitoring-agent-ui/src/components/Monitors.vue
@@ -115,6 +115,12 @@ export default {
                                         v-if="monitor.lastError != null" :key="monitor._id" data-bs-toggle="tooltip"
                                         data-bs-placement="top" v-bind:title="monitor.lastError">{{ monitor.lastError }}
                                     </dd>
+                                    <dt class="col-sm-12 small no-margin" v-if="monitor.description">Description
+                                    </dt>                                    
+                                    <dd class="col-sm-12 small no-margin xtext-truncate"
+                                        v-if="monitor.description != null" :key="monitor._id" data-bs-toggle="tooltip"
+                                        data-bs-placement="top" v-bind:title="monitor.description">{{ monitor.description }}
+                                    </dd>                                    
                                 </dl>
                             </div>
                         </div>


### PR DESCRIPTION
Adds a description field to the monitors. This field is used to provide
a description of the monitor. This description is displayed in the UI.
    
Breaking changes: None
    
Resolves: #167
