### PR TITLE
fix:Issue-173:Fix max memory test for process

### DIFF
--- a/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
@@ -206,7 +206,7 @@ impl ProcessMonitor {
         let Some(pagesize) = statm.pagesize else { return Status::Ok };
         let Some(max_mem_usage) = self.max_mem_usage else { return Status::Ok };    
         if (resident * pagesize) > max_mem_usage {
-            return Status::Error { message: format!("Process memory usage is over the limit: {resident:?} > {max_mem_usage:?}")};
+            return Status::Error { message: format!("Process memory usage is over the limit: {:?} > {max_mem_usage:?}", (resident * pagesize))};
         }
         Status::Ok
     }
@@ -352,7 +352,7 @@ mod test {
             "systemd monitor",
             &None,
             &vec!["/sbin/init".to_string()],
-            Some(1000000),
+            Some(100000000),
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &DatabaseStoreLevel::None,

--- a/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/processmonitor.rs
@@ -202,10 +202,11 @@ impl ProcessMonitor {
      * Returns: The status of the check.
      */
     fn check_max(&self, statm: &ProcsStatm) -> Status {        
-        let Some(statm_size) = statm.size else { return Status::Ok };   
+        let Some(resident) = statm.resident else { return Status::Ok };   
+        let Some(pagesize) = statm.pagesize else { return Status::Ok };
         let Some(max_mem_usage) = self.max_mem_usage else { return Status::Ok };    
-        if statm_size > max_mem_usage {
-            return Status::Error { message: format!("Process memory usage is over the limit: {statm_size:?} > {max_mem_usage:?}")};
+        if (resident * pagesize) > max_mem_usage {
+            return Status::Error { message: format!("Process memory usage is over the limit: {resident:?} > {max_mem_usage:?}")};
         }
         Status::Ok
     }


### PR DESCRIPTION
Changes max memory test for process to use the correct value. Now it tests max value against resident * page size.

Breaking changes: None

Resolves: #173