### PR TITLE
feat:Issue-150:Implement history api for loadaverage

### DIFF
--- a/monitoring-agent-daemon/src/api/loadavg.rs
+++ b/monitoring-agent-daemon/src/api/loadavg.rs
@@ -1,14 +1,15 @@
-use actix_web::{get, web, HttpResponse, Responder};
+use actix_web::{get, web, HttpRequest, HttpResponse, Responder};
 
 use crate::api::common::set_cors_headers;
+use crate::api::request::HistoricalParams;
+use crate::api::response::{LoadavgHistoricalResponse, LoadavgResponse};
 use crate::api::StateApi;
-use crate::api::response::LoadavgResponse;
 
 /**
  * Get current load average.
- * 
+ *
  * `state`: The state object.
- * 
+ *
  * Returns the load average or an error.
  */
 #[get("/loadavg/current")]
@@ -19,6 +20,50 @@ pub async fn get_current_loadavg(state: web::Data<StateApi>) -> impl Responder {
             let mut response_builder = HttpResponse::Ok();
             set_cors_headers(&mut response_builder, &state.server_config);
             response_builder.json(LoadavgResponse::from_loadavg(&loadavg))
+        }
+        Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
+    }
+}
+
+/**
+ * Get historical load average.
+ *
+ * `state`: The state object.
+ *
+ * Returns the historical load average or an error.
+ */
+#[get("/loadavg/historical")]
+pub async fn get_historical_loadavg(
+    state: web::Data<StateApi>,
+    req: HttpRequest,
+) -> impl Responder {
+    /*
+     * If the database service is not found, return a 404. 
+     */
+    let Some(db_service) = state.database_service.as_ref() else {
+        return HttpResponse::NotFound().body("Database service not found");
+    };
+    /*
+     * Parse the query string.
+     */
+    let params = match web::Query::<HistoricalParams>::from_query(req.query_string()) {
+        Ok(params) => params,
+        Err(err) => {
+            return HttpResponse::BadRequest().body(format!("Error parsing query string: {err:?}"))
+        }
+    };
+    /*
+     * Get the historical load average.
+     */
+    let loadavg = db_service.get_historical_loadavg(params.0);
+    /*
+     * Return the response.
+     */
+    match loadavg {
+        Ok(loadavg) => {
+            let mut response_builder = HttpResponse::Ok();
+            set_cors_headers(&mut response_builder, &state.server_config);
+            response_builder.json(LoadavgHistoricalResponse::from_loadavg_historical(&loadavg))
         }
         Err(err) => HttpResponse::InternalServerError().body(format!("Error occured: {err:?}")),
     }

--- a/monitoring-agent-daemon/src/api/mod.rs
+++ b/monitoring-agent-daemon/src/api/mod.rs
@@ -23,14 +23,16 @@ mod monitor;
 mod common;
 mod stat;
 mod ping;
+mod request;
 
 pub use crate::api::meminfo::get_current_meminfo;
 pub use crate::api::cpuinfo::get_current_cpuinfo;
-pub use crate::api::loadavg::get_current_loadavg;
+pub use crate::api::loadavg::{get_current_loadavg, get_historical_loadavg};
 pub use crate::api::process::{get_processes, get_process, get_threads, get_current_statm};
 pub use crate::api::monitor::get_monitor_status;
 pub use crate::api::stat::get_stat;
 pub use crate::api::ping::get_ping;
+pub use crate::api::request::HistoricalParams;
 
 #[allow(clippy::module_name_repetitions)]
 pub use crate::api::state::StateApi;

--- a/monitoring-agent-daemon/src/api/request.rs
+++ b/monitoring-agent-daemon/src/api/request.rs
@@ -1,0 +1,46 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+/**
+ * The historical parameters. Used to represent the historical parameters.
+ * 
+ * `from_datetime`: The from date time.
+ * `to_datetime`: The to date time.
+ * `split`: The split. One is every minute 2 is every two minutes.
+ */
+#[derive(Debug, Deserialize)]
+pub struct HistoricalParams {
+    /// The from date time.
+    #[serde(rename = "fromDateTime", default = "default_from_datetime")]
+    pub from_datetime: DateTime<Utc>,
+    /// The to date time.
+    #[serde(rename = "toDateTime", default = "Utc::now")]
+    pub to_datetime: DateTime<Utc>,
+    /// The split. One is every minute 2 is every two minutes.
+    #[serde(rename = "split", default = "default_split")]
+    pub split: u16,
+    /// The server.
+    #[serde(rename = "server", default = "default_server")]
+    pub server: String,    
+}
+
+/**
+ * The default from date time.
+ */
+fn default_from_datetime() -> DateTime<Utc> {
+    Utc::now() - chrono::Duration::days(1)
+}
+
+/**
+ * The default split.
+ */
+fn default_split() -> u16 {
+    1
+}
+
+/**
+ * The default server.
+ */
+fn default_server() -> String {
+    "localhost".to_string()
+}

--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, TimeZone, Utc };
 use monitoring_agent_lib::proc::{process::ProcessState, ProcStat, ProcsCpuinfo, ProcsLoadavg, ProcsMeminfo, ProcsProcess, ProcsStatm};
 use serde::{Deserialize, Serialize};
 
-use crate::common::{MonitorStatus, Status};
+use crate::common::{LoadavgElement, MonitorStatus, Status};
 
 /**
  * The `MeminfoResponse` struct represents the response of the meminfo endpoint.
@@ -733,6 +733,78 @@ impl StatResponse {
     }
 
 }
+
+/**
+ * The `LoadavgHistoricalResponse` struct represents the response of the loadavg historical endpoint.
+ * The loadavg historical endpoint is used to get the historical load average.
+ * 
+ * The loadavg historical endpoint contains the following columns:
+ * * The 1 minute load average.
+ * * The 5 minute load average.
+ * * The 15 minute load average.
+ */
+#[allow(clippy::similar_names)]
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadavgHistoricalResponse {  
+    /// The 1 minute load average.  
+    pub loadavg1min: Vec<HistoryElement>,
+    /// The 5 minute load average.
+    pub loadavg5min: Vec<HistoryElement>,
+    /// The 15 minute load average.
+    pub loadavg15min: Vec<HistoryElement>,
+}
+
+impl LoadavgHistoricalResponse {
+    /**
+     * Create a new `LoadavgHistoricalResponse`.
+     * 
+     * `loadavg1min`: The 1 minute load average.
+     * `loadavg5min`: The 5 minute load average.
+     * `loadavg15min`: The 15 minute load average.
+     * 
+     * Returns a new `LoadavgHistoricalResponse`.
+     * 
+     */
+    #[allow(clippy::similar_names)]
+    pub fn new(
+        loadavg1min: Vec<HistoryElement>,
+        loadavg5min: Vec<HistoryElement>,
+        loadavg15min: Vec<HistoryElement>,
+    ) -> LoadavgHistoricalResponse {
+        LoadavgHistoricalResponse {
+            loadavg1min,
+            loadavg5min,
+            loadavg15min,
+        }
+    }
+
+    pub fn from_loadavg_historical(loadavg: &[LoadavgElement]) -> LoadavgHistoricalResponse {
+        LoadavgHistoricalResponse::new(
+            loadavg.iter().map(|element| HistoryElement {
+                timestamp: element.timestamp,
+                value: element.loadavg1min,
+            }).collect(),
+            loadavg.iter().map(|element| HistoryElement {
+                timestamp: element.timestamp,
+                value: element.loadavg5min,
+            }).collect(),
+            loadavg.iter().map(|element| HistoryElement {
+                timestamp: element.timestamp,
+                value: element.loadavg15min,
+            }).collect(),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryElement {
+    #[serde(rename = "timestamp")]
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "value")]
+    pub value: f64,
+}
+
 
 #[cfg(test)]
 mod test {

--- a/monitoring-agent-daemon/src/api/state.rs
+++ b/monitoring-agent-daemon/src/api/state.rs
@@ -1,4 +1,6 @@
-use crate::{common::configuration::ServerConfig, services::MonitoringService};
+use std::sync::Arc;
+
+use crate::{common::configuration::ServerConfig, services::{DbService, MonitoringService}};
 
 /**
  * State object for the API modules.
@@ -7,6 +9,8 @@ use crate::{common::configuration::ServerConfig, services::MonitoringService};
 pub struct StateApi {
     /// Monitoring service object.
     pub monitoring_service: MonitoringService,
+    /// Database service object.
+    pub database_service: Arc<Option<DbService>>,    
     /// Server configuration object.
     pub server_config: ServerConfig,
     /// Monitored application names.
@@ -18,15 +22,17 @@ impl StateApi {
      * Constructor for `MeminfoApi`
      * 
      * @param `monitoring_service` `MonitoringService` The monitoring service object.
+     * @param `database_service` `Arc<DbService>` The database service object.
      * @param `server_config` `ServerConfig` The server configuration object.
      * @param `monitered_application_names` `&Vec<String>` The monitored application names.
      * 
      * @return `StateApi`
      * 
      */
-    pub fn new(monitoring_service: MonitoringService, server_config: ServerConfig, monitered_application_names: &[String]) -> StateApi {
+    pub fn new(monitoring_service: MonitoringService, database_service: Arc<Option<DbService>>, server_config: ServerConfig, monitered_application_names: &[String]) -> StateApi {
         StateApi {
             monitoring_service,
+            database_service,
             server_config,
             monitered_application_names: monitered_application_names.iter().map(|f| f.chars().take(15).collect()).collect(),
         }

--- a/monitoring-agent-daemon/src/common/historical.rs
+++ b/monitoring-agent-daemon/src/common/historical.rs
@@ -1,0 +1,44 @@
+use chrono::{DateTime, Utc};
+
+/**
+ * The load average element. Used to represent a load average element.
+ * 
+ * `timestamp`: The timestamp.
+ * `loadavg1min`: The 1 minute load average.
+ * `loadavg5min`: The 5 minute load average.
+ * `loadavg15min`: The 15 minute load average.
+ */
+#[allow(clippy::similar_names)]
+#[derive(Debug, Clone)]
+pub struct LoadavgElement {
+    /// The timestamp.    
+    pub timestamp: DateTime<Utc>,
+    /// The 1 minute load average.
+    pub loadavg1min: f64,
+    /// The 5 minute load average.
+    pub loadavg5min: f64,
+    /// The 15 minute load average.
+    pub loadavg15min: f64,
+}
+
+impl LoadavgElement {
+    /**
+     * Create a new load average element.
+     * 
+     * `timestamp`: The timestamp.
+     * `loadavg1min`: The 1 minute load average.
+     * `loadavg5min`: The 5 minute load average.
+     * `loadavg15min`: The 15 minute load average.
+     * 
+     * Returns the load average element.
+     */
+    #[allow(clippy::similar_names)]
+    pub fn new(timestamp: DateTime<Utc>, loadavg1min: f64, loadavg5min: f64, loadavg15min: f64) -> LoadavgElement {
+        LoadavgElement {
+            timestamp,
+            loadavg1min,
+            loadavg5min,
+            loadavg15min,
+        }
+    }
+}

--- a/monitoring-agent-daemon/src/common/mod.rs
+++ b/monitoring-agent-daemon/src/common/mod.rs
@@ -5,13 +5,16 @@
  * `monitorstatus`: The monitor status. Used to represent the status of a monitor in the services.
  * `configuration`: The configuration. Used to represent the configuration of the monitoring agent daemon.
  * `args`: The application arguments. Used to represent the arguments passed to the application.
+ * `historical`: The historical data. Used to represent the historical data of the monitoring agent daemon.
  */
 mod applicationerror;
 mod monitorstatus;
 pub mod configuration;
 pub mod args;
+pub mod historical;
 
 pub use crate::common::applicationerror::ApplicationError;
 pub use crate::common::monitorstatus::{MonitorStatus, Status};
 pub use crate::common::configuration::{Monitor, MonitorType, HttpMethod, DatabaseConfig};
 pub use crate::common::args::ApplicationArguments;
+pub use crate::common::historical::LoadavgElement;

--- a/monitoring-agent-daemon/src/services/monitoringservice.rs
+++ b/monitoring-agent-daemon/src/services/monitoringservice.rs
@@ -20,7 +20,7 @@ use crate::common::{ApplicationError, MonitorStatus};
 #[derive(Clone)]
 pub struct MonitoringService {
     /// The status of the monitors.
-    status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
+    status: Arc<Mutex<HashMap<String, MonitorStatus>>>
 }
 
 impl MonitoringService {
@@ -216,6 +216,7 @@ impl MonitoringService {
             }
         }
     }
+
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implements the history api for loadaverage. This api will return the historical data for the loadaverage. The data returned is the loadaverage 1 min, 5 min and 15 min averaged over time.

The following information are optional parameters for the api:
- start_time: The start time of the historical data to be returned.
- end_time: The end time of the historical data to be returned.
- split: How large the time interval should be for the historical data.
- server: The server to get the historical data for.

Only implemented for mysql/mariadb for now.

Breaking changes: None

Resolves: #150