### PR TITLE
feat:Issue-180:Improve ping api

### DIFF
--- a/monitoring-agent-daemon/src/api/ping.rs
+++ b/monitoring-agent-daemon/src/api/ping.rs
@@ -13,5 +13,5 @@ use crate::api::{common::set_cors_headers, response::PingResponse, StateApi};
 pub async fn get_ping(state: web::Data<StateApi>) -> impl Responder {
     let mut response_builder = HttpResponse::Ok();
     set_cors_headers(&mut response_builder, &state.server_config);
-    response_builder.json(PingResponse::new("Ok","monitoring-agent-daemon"))  
+    response_builder.json(PingResponse::new("Ok","monitoring-agent-daemon", &state.server_config.name))  
 }

--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -581,19 +581,22 @@ impl StatmResponse {
  * 
  * `status`: The status of the monitoring agent daemon. Should always be Ok.
  * `system`: The system the monitoring agent daemon is running on. Should always be monitoring-agent-daemon.
+ * `name`: The name of the monitoring agent daemon. From configuration file.
  */
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PingResponse {
     status: String,
-    system: String
+    system: String,
+    name: String,
 }
 
 impl PingResponse {
-    pub fn new(status: &str, system: &str) -> PingResponse {
+    pub fn new(status: &str, system: &str, name: &str) -> PingResponse {
         PingResponse {
             status: status.to_string(),
-            system: system.to_string()
+            system: system.to_string(),
+            name: name.to_string(),
         }
     }
 }


### PR DESCRIPTION
Adds server name to the ping response. This is required to know what server is responding to the ping request and what name to query for whe  getting historical data.

Breaking changes: None

Resolves: #180