### PR TITLE
feat:Issue-195:Implement process memory use api

### DIFF
--- a/monitoring-agent-daemon/src/api/mod.rs
+++ b/monitoring-agent-daemon/src/api/mod.rs
@@ -28,7 +28,7 @@ mod request;
 pub use crate::api::meminfo::{get_current_meminfo, get_historical_meminfo};
 pub use crate::api::cpuinfo::get_current_cpuinfo;
 pub use crate::api::loadavg::{get_current_loadavg, get_historical_loadavg};
-pub use crate::api::process::{get_processes, get_process, get_threads, get_current_statm};
+pub use crate::api::process::{get_processes, get_process, get_threads, get_current_statm, get_historical_statm};
 pub use crate::api::monitor::get_monitor_status;
 pub use crate::api::stat::get_stat;
 pub use crate::api::ping::get_ping;

--- a/monitoring-agent-daemon/src/common/historical.rs
+++ b/monitoring-agent-daemon/src/common/historical.rs
@@ -78,3 +78,61 @@ impl MeminfoElement {
         }
     }
 }
+
+/**
+ * The used process memory element.
+ * 
+ * `timestamp`: The timestamp.
+ * `resident`: Size of memory portions (pages)
+ * `share`: Number of pages that are shared
+ * `trs`: Number of pages that are ‘code’
+ * `drs`: Number of pages of data/stack
+ * `lrs`: Number of pages of library
+ * `dt`: Number of dirty pages
+ */
+#[allow(clippy::similar_names)]
+#[derive(Debug, Clone)]
+pub struct ProcessMemoryElement {
+    /// The timestamp.    
+    pub timestamp: DateTime<Utc>,
+    /// Size of memory portions (pages)
+    pub resident: Option<u64>,
+    /// Number of pages that are shared
+    pub share: Option<u64>,
+    /// Number of pages that are ‘code’
+    pub trs: Option<u64>,
+    /// Number of pages of data/stack
+    pub drs: Option<u64>,
+    /// Number of pages of library
+    pub lrs: Option<u64>,
+    /// Number of dirty pages
+    pub dt: Option<u64>,
+}
+
+impl ProcessMemoryElement {
+    /**
+     * Create a new process memory element.
+     * 
+     * `timestamp`: The timestamp.
+     * `resident`: Size of memory portions (pages)
+     * `share`: Number of pages that are shared
+     * `trs`: Number of pages that are ‘code’
+     * `drs`: Number of pages of data/stack
+     * `lrs`: Number of pages of library
+     * `dt`: Number of dirty pages
+     * 
+     * Returns the process memory element.
+     */
+    #[allow(clippy::similar_names)]
+    pub fn new(timestamp: DateTime<Utc>, resident: Option<u64>, share: Option<u64>, trs: Option<u64>, drs: Option<u64>, lrs: Option<u64>, dt: Option<u64>) -> ProcessMemoryElement {
+        ProcessMemoryElement {
+            timestamp,
+            resident,
+            share,
+            trs,
+            drs,
+            lrs,
+            dt,
+        }
+    }
+}

--- a/monitoring-agent-daemon/src/common/mod.rs
+++ b/monitoring-agent-daemon/src/common/mod.rs
@@ -17,4 +17,4 @@ pub use crate::common::applicationerror::ApplicationError;
 pub use crate::common::monitorstatus::{MonitorStatus, Status};
 pub use crate::common::configuration::{Monitor, MonitorType, HttpMethod, DatabaseConfig};
 pub use crate::common::args::ApplicationArguments;
-pub use crate::common::historical::LoadavgElement;
+pub use crate::common::historical::{LoadavgElement, MeminfoElement, ProcessMemoryElement};

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -201,6 +201,7 @@ async fn init_http_server(monitoring_config: &MonitoringConfig, monitoring_servi
             .service(api::get_current_loadavg)  
             .service(api::get_historical_loadavg) 
             .service(api::get_processes)
+            .service(api::get_historical_statm)
             .service(api::get_process)
             .service(api::get_threads)
             .service(api::get_monitor_status)


### PR DESCRIPTION
Implements the process memory use api. This api returns the memory usage of a process in bytes. The api is available at /processes/{pid}/statm/historical.
It returns all memory fields except for the total memory field.

Breaking changes: None

Resolves: #195