### PR TITLE
feat:Issue-204:Add pid and regexp to process monitor

### DIFF
--- a/monitoring-agent-daemon/Cargo.toml
+++ b/monitoring-agent-daemon/Cargo.toml
@@ -34,7 +34,8 @@ rust_decimal = { version = "1.35.0", features = ["db-postgres"] }               
 tracing = "0.1.40"                                                                      # For logging.
 tracing-subscriber = "0.3.18"                                                           # For logging.
 tracing-log = "0.2.0"                                                                   # For logging.
-openssl = "0.10.35"                                                                     # For handling openssl.
+openssl = "0.10.66"                                                                     # For handling openssl.
+regex = "1.10.6"                                                                        # For regular expressions.
 
 [package.metadata.deb]
 maintainer = "Kjetil Fjellheim <kjetil@forgottendonkey.net>"

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -83,7 +83,13 @@ pub enum MonitorType {
     Process {
         /// Aplication names to monitor.
         #[serde(rename = "applicationNames")]
-        application_names: Vec<String>,
+        application_names: Option<Vec<String>>,
+        /// Pids to monitor.
+        #[serde(rename = "pids")] 
+        pids: Option<Vec<u32>>,
+        /// Regexp on name.
+        #[serde(rename = "regexp")] 
+        regexp: Option<String>,        
         /// The maximum memory usage.
         #[serde(skip_serializing_if = "Option::is_none", rename = "maxMemUsage")]
         max_mem_usage: Option<u32>,        
@@ -628,7 +634,9 @@ mod tests {
         assert_eq!(
             monitor,
             MonitorType::Process { 
-                application_names: vec!["app1".to_string(), "app2".to_string()],
+                application_names: Some(vec!["app1".to_string(), "app2".to_string()]),
+                pids: None,
+                regexp: None,
                 max_mem_usage: Some(100),
                 store_values: true,
                 

--- a/monitoring-agent-daemon/src/main.rs
+++ b/monitoring-agent-daemon/src/main.rs
@@ -6,11 +6,10 @@ use std::fs::File;
 use std::io::Read;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::vec;
 
 use clap::Parser;
 use common::configuration::{DatabaseConfig, MonitoringConfig, ServerConfig};
-use common::{ApplicationError, MonitorType};
+use common::ApplicationError;
 use daemonize::Daemonize;
 use log::{debug, error, info};
 use actix_web::{web, App, HttpServer};
@@ -120,11 +119,11 @@ async fn start_application(monitoring_config: &MonitoringConfig, args: &Applicat
     if args.test {
         return Ok(());
     }
-    let monitered_application_names = get_applications(monitoring_config);
     /*
      * Initialize the HTTP server.
      */
-    init_http_server(monitoring_config, monitoring_service, database_service, monitered_application_names).await
+    //Fix monitored application names
+    init_http_server(monitoring_config, monitoring_service, database_service, Vec::new()).await
 }
 
 /**
@@ -224,33 +223,6 @@ async fn init_http_server(monitoring_config: &MonitoringConfig, monitoring_servi
     };
     http_server.run()
     .await
-}
-
-/**
- * Get applications that are being monitored.
- * 
- * `monitoring_config`: The monitoring configuration.
- * 
- * Returns the applications.
- * 
- */
-fn get_applications(monitoring_config: &MonitoringConfig) -> Vec<String> {
-    monitoring_config
-        .monitors
-        .iter()
-        .flat_map(|monitor| match monitor.details.clone() {
-            MonitorType::Process { application_names, max_mem_usage: _, store_values } => {
-                if store_values {
-                    application_names.clone()
-                } else {
-                    vec![]
-                }
-            }
-            _ => {
-                vec![]
-            }
-        })
-        .collect()
 }
 
 /** 

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -219,9 +219,9 @@ impl SchedulingService {
                 let job = database_monitor.get_database_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
-            crate::common::MonitorType::Process { application_names, max_mem_usage, store_values 
+            crate::common::MonitorType::Process { application_names, pids, regexp, max_mem_usage, store_values 
             } => {
-                let mut process_monitor = ProcessMonitor::new(&monitor.name, &monitor.description, &application_names, max_mem_usage, &self.status, &self.database_service.clone(), &monitor.store, store_values);
+                let mut process_monitor = ProcessMonitor::new(&monitor.name, &monitor.description, application_names, pids, regexp, max_mem_usage, &self.status, &self.database_service.clone(), &monitor.store, store_values);
                 let job = process_monitor.get_process_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },


### PR DESCRIPTION
Changes the process monitor to be able to monitor a process by its pid and a regular expression. This is useful for monitoring processes that are started by a script or similar.

Changes the name check from using cmdline to using name in status file.

Breaking changes: None

Resolves: #204