### PR TITLE
feat:Issue-154:Add configuration for deleting historical data

### DIFF
--- a/monitoring-agent-daemon/Cargo.toml
+++ b/monitoring-agent-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitoring-agent-daemon"
-version = "0.0.23"
+version = "0.0.24"
 edition = "2021"
 description = "A monitoring agent that can be used to monitor the health of a system."
 license = "Apache 2.0"
@@ -11,18 +11,18 @@ authors = ["Kjetil Fjellheim <kjetil@forgottendonkey.net>"]
 categories = ["monitoring", "health", "system"]
 
 [dependencies]
-serde = { version = "1.0.205", features = ["derive", ] }                                # For serializing/deserializing.
-serde_json = { version = "1.0.122", features = []}                                      # For serializing/deserializing.
+serde = { version = "1.0.209", features = ["derive", ] }                                # For serializing/deserializing.
+serde_json = { version = "1.0.128", features = []}                                      # For serializing/deserializing.
 tokio-cron-scheduler = "0.11.0"                                                         # For schduling jobs.
-tokio = { version = "1.39.2", features = ["full"] }                                     # For schduling jobs.
-clap = { version = "4.5.14", features = ["derive"] }                                    # For parsing input arguments.
+tokio = { version = "1.40.0", features = ["full"] }                                     # For schduling jobs.
+clap = { version = "4.5.17", features = ["derive"] }                                    # For parsing input arguments.
 daemonize = "0.5.0"                                                                     # For daemonizing the process.
-reqwest = { version = "0.12.5", features = ["blocking", "native-tls"]}                  # For handling http requests.
+reqwest = { version = "0.12.7", features = ["blocking", "native-tls"]}                  # For handling http requests.
 futures = "0.3.30"                                                                      # For better handling of futures.
 native-tls = "0.2.12"                                                                   # Use native tls for reqwest.
 log4rs = { version = "1.3.0"}                                                           # For logging.
 log = { version = "0.4.22" }                                                            # For logging.
-actix-web = { version = "4.8.0" , features = ["openssl"]}                               # For handling http requests.
+actix-web = { version = "4.9.0" , features = ["openssl"]}                               # For handling http requests.
 chrono = { version = "0.4.38", features = ["serde"]}                                    # For handling time.
 monitoring-agent-lib = { path = "../monitoring-agent-lib" }                             # For reading system information.
 r2d2 = { version = "0.8.10", features = [   ]}                                          # For handling connection pools.
@@ -30,7 +30,7 @@ r2d2_mysql = "25.0.0"                                                           
 r2d2_postgres = "0.18.1"                                                                # For handling postgres connections.
 bb8 = "0.8.5"                                                                           # For handling connection pools.
 bb8-postgres = "0.8.1"                                                                  # For handling postgres connections.
-rust_decimal = { version = "1.35.0", features = ["db-postgres"] }                       # For handling decimal numbers towards databases.
+rust_decimal = { version = "1.36.0", features = ["db-postgres"] }                       # For handling decimal numbers towards databases.
 tracing = "0.1.40"                                                                      # For logging.
 tracing-subscriber = "0.3.18"                                                           # For logging.
 tracing-log = "0.2.0"                                                                   # For logging.

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -181,7 +181,9 @@ pub struct MonitoringConfig {
     /// The list of monitors.
     #[serde(rename = "monitors")]
     pub monitors: Vec<Monitor>,
-
+    /// Cleanup configuration.
+    #[serde(rename = "cleanupConfig")]
+    pub cleanup_config: Option<CleanupConfig>,
 
 }
 
@@ -229,6 +231,16 @@ impl MonitoringConfig {
             )),
         }
     }
+}
+
+/**
+ * Cleanup configuration.
+ */
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct CleanupConfig {
+    /// Hours to keep information in the database.
+    #[serde(rename = "removeFromDbAfter", default = "default_none")]
+    pub max_time_stored_db: Option<u32>,
 }
 
 /**
@@ -409,11 +421,17 @@ fn default_max_lifetime() -> u32 {
     300
 }
 
+/** 
+ * Default tokio stack size.
+ */
 fn default_tokio_stack_size() -> usize {
     debug!("Using default tokio stack size");
     2 * 1024
 }
 
+/** 
+ * Default tokio threads.
+ */
 fn default_tokio_threads() -> usize {
     debug!("Using default tokio threads");
     4

--- a/monitoring-agent-daemon/src/services/jobs/dbcleanupjob.rs
+++ b/monitoring-agent-daemon/src/services/jobs/dbcleanupjob.rs
@@ -76,3 +76,31 @@ impl DbCleanupJob {
         }
     }
 }
+
+mod test {
+    #[cfg(test)]
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let db_service = Arc::new(None);
+        let db_cleanup_job = DbCleanupJob::new(&db_service, 24);
+        assert_eq!(db_cleanup_job.max_time_stored_db, 24);
+    }
+
+    #[test]
+    fn test_get_db_cleanup_job() {
+        let db_service = Arc::new(None);
+        let mut db_cleanup_job = DbCleanupJob::new(&db_service, 24);
+        let job = db_cleanup_job.get_db_cleanup_job();
+        assert!(job.is_ok());
+    }
+
+    #[test]
+    fn test_delete_if_no_db_configured() {
+        let db_service = Arc::new(None);
+        let db_cleanup_job = DbCleanupJob::new(&db_service, 24);
+        let result = db_cleanup_job.delete();
+        assert!(result.is_err());
+    }
+}

--- a/monitoring-agent-daemon/src/services/jobs/dbcleanupjob.rs
+++ b/monitoring-agent-daemon/src/services/jobs/dbcleanupjob.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use log::info;
+use tokio_cron_scheduler::Job;
+use tracing::error;
+
+use crate::{common::ApplicationError, services::DbService};
+
+/**
+ * The `DbCleanupJob` struct contains the database service and the maximum time stored in the database.
+ *  
+ * The `DbCleanupJob` struct has the following fields:
+ * * `db_service`: Database service if defined.
+ * * `max_time_stored_db`: Max number of hours to store data in the database.
+ * 
+ */
+#[derive(Debug, Clone)]
+pub struct DbCleanupJob {
+    pub db_service: Arc<Option<DbService>>,
+    pub max_time_stored_db: u32
+}
+
+impl DbCleanupJob {
+    /**
+     * Create a new `DbCleanupJob` with the database service and the maximum time stored in the database.
+     * 
+     * # Arguments
+     * * `db_service` - The database service.
+     * * `max_time_stored_db` - The maximum time stored in the database.
+     * 
+     * # Returns
+     * The `DbCleanupJob` with the database service and the maximum time stored in the database.
+     */
+    pub fn new(db_service: &Arc<Option<DbService>>, max_time_stored_db: u32) -> Self {
+        DbCleanupJob {
+            db_service: db_service.clone(),
+            max_time_stored_db
+        }
+    }
+
+    /**
+     * Get the database cleanup job.
+     * 
+     * # Returns
+     * The database cleanup job.
+     */
+    pub fn get_db_cleanup_job(&mut self) -> Result<Job, ApplicationError> {
+        let db_cleanup_job = self.clone();
+        let job_result = Job::new_async("0 */5 * * * *", move |_uuid, _locked| {
+            let db_cleanup_job = db_cleanup_job.clone();
+            Box::pin(async move {
+                let _ = db_cleanup_job.delete().map_err(|err| {
+                    error!("Error checking monitor: {:?}", err);
+                });
+            })
+        });
+        job_result.map_err(|err| ApplicationError::new(&format!("Error creating db cleanup job: {err:?}")))        
+    }
+
+    /**
+     * Delete the old data from the database.
+     * 
+     * # Returns
+     * The result of the database cleanup job.
+     */
+    fn delete(&self) -> Result<(), ApplicationError> {
+        info!("Running db cleanup job");        
+        let db_service = self.db_service.as_ref();
+        match db_service {
+            None => {
+                Err(ApplicationError::new("Database service not found"))
+            }
+            Some(db_service) => {
+                db_service.delete_old_data(self.max_time_stored_db)
+            }
+        }
+    }
+}

--- a/monitoring-agent-daemon/src/services/jobs/mod.rs
+++ b/monitoring-agent-daemon/src/services/jobs/mod.rs
@@ -1,0 +1,3 @@
+mod dbcleanupjob;
+
+pub use dbcleanupjob::DbCleanupJob;

--- a/monitoring-agent-daemon/src/services/mod.rs
+++ b/monitoring-agent-daemon/src/services/mod.rs
@@ -10,6 +10,7 @@ mod monitors;
 mod monitoringservice;
 mod schedulingservice;
 mod databaseservice;
+mod jobs;
 
 pub use monitoringservice::MonitoringService;
 pub use schedulingservice::SchedulingService;

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -4,7 +4,7 @@ use log::info;
 use tokio_cron_scheduler::{Job, JobScheduler};
 
 use crate::common::{configuration::MonitoringConfig, ApplicationError, MonitorStatus};
-use crate::services::DbService;
+use crate::services::{DbService, jobs::DbCleanupJob};
 use super::monitors::{CommandMonitor, HttpMonitor, LoadAvgMonitor, MeminfoMonitor, SystemctlMonitor, TcpMonitor, DatabaseMonitor, ProcessMonitor};
 
 /**
@@ -99,7 +99,20 @@ impl SchedulingService {
         let monitors = self.monitoring_config.clone().monitors;
         for monitor in monitors {
             self.create_and_add_job(&monitor, &scheduler).await?;
-        }                 
+        }
+
+        /*
+         * Create a cleanup jobs.
+         */
+        let cleanup_config = self.monitoring_config.cleanup_config.clone();
+        if let Some(cleanup_config) = cleanup_config {
+            let max_time_stored_db = cleanup_config.max_time_stored_db;
+            if let Some(max_time_stored_db) = max_time_stored_db {
+                let mut cleanup_job = DbCleanupJob::new(&self.database_service, max_time_stored_db);
+                let job = cleanup_job.get_db_cleanup_job()?;
+                self.add_job(&scheduler, job).await?;
+            }
+        }
         /*
          * Start the scheduler.
          */

--- a/monitoring-agent-lib/Cargo.toml
+++ b/monitoring-agent-lib/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "monitoring-agent-lib"
-version = "0.0.23"
+version = "0.0.24"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.205", features = ["derive", ] }                                # For serializing/deserializing.
-serde_json = { version = "1.0.122" }                                                    # For serializing/deserializing.
+serde = { version = "1.0.209", features = ["derive", ] }                                # For serializing/deserializing.
+serde_json = { version = "1.0.128" }                                                    # For serializing/deserializing.
 log = { version = "0.4.22" }                                                            # For logging.
 regex = "1.10.6"                                                                        # For regular expressions.
 tracing = "0.1.40"                                                                      # For logging.

--- a/monitoring-agent-ui/package.json
+++ b/monitoring-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monitoring-agent-ui",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/monitoring-agent-ui/package.json
+++ b/monitoring-agent-ui/package.json
@@ -27,8 +27,8 @@
     "@vitejs/plugin-vue": "5.1.3",
     "@vue/eslint-config-prettier": "9.0.0",
     "eslint": "9.9.1",
-    "eslint-plugin-vue": "9.27.0",
+    "eslint-plugin-vue": "9.28.0",
     "prettier": "3.3.3",
-    "vite": "5.4.2"
+    "vite": "5.4.3"
   }
 }


### PR DESCRIPTION
Adds a configurable job to delete historical data from the database. The
job is scheduled to run at every 5 minutes. How long data is kept is
configurable in the configuration file.
    
Breaking changes: None
    
Resolves: #154
