### PR TITLE
feat:Issue-211:Fix issue when getconf is missing

### DIFF
--- a/monitoring-agent-lib/Cargo.toml
+++ b/monitoring-agent-lib/Cargo.toml
@@ -9,3 +9,4 @@ serde_json = { version = "1.0.128" }                                            
 log = { version = "0.4.22" }                                                            # For logging.
 regex = "1.10.6"                                                                        # For regular expressions.
 tracing = "0.1.40"                                                                      # For logging.
+libc = "0.2.158"                                                                        # For sysconf.

--- a/monitoring-agent-lib/src/proc/statm.rs
+++ b/monitoring-agent-lib/src/proc/statm.rs
@@ -1,10 +1,15 @@
-use std::{fs::File, io::BufReader, io::BufRead};
+use std::{
+    fs::File,
+    io::{BufRead, BufReader}
+};
+
+use libc::{sysconf, _SC_PAGE_SIZE};
 
 use crate::common::CommonLibError;
 
 /**
  * Process memory structure from /proc/{pid}/statm
- * 
+ *
  * TODO: Add more detailed text.
  */
 #[allow(clippy::module_name_repetitions)]
@@ -25,13 +30,13 @@ pub struct ProcsStatm {
     /// Number of dirty pages
     pub dt: Option<u32>,
     /// Pagesize
-    pub pagesize: Option<u32>
+    pub pagesize: Option<u32>,
 }
 
 impl ProcsStatm {
     /**
      * Create a new `Statm`.
-     * 
+     *
      * `size`: Total program size (pages)
      * `resident`: Size of memory portions (pages)
      * `share`: Number of pages that are shared
@@ -40,11 +45,12 @@ impl ProcsStatm {
      * `lrs`: Number of pages of library
      * `dt`: Number of dirty pages
      * `pagesize`: Pagesize
-     * 
+     *
      * Returns a new `Statm`.
      */
     #[allow(clippy::too_many_arguments)]
-    #[must_use] pub fn new(
+    #[must_use]
+    pub fn new(
         size: &Option<u32>,
         resident: &Option<u32>,
         share: &Option<u32>,
@@ -52,9 +58,8 @@ impl ProcsStatm {
         drs: &Option<u32>,
         lrs: &Option<u32>,
         dt: &Option<u32>,
-        pagesize: &Option<u32>
+        pagesize: &u32,
     ) -> ProcsStatm {
-
         ProcsStatm {
             size: *size,
             resident: *resident,
@@ -63,20 +68,20 @@ impl ProcsStatm {
             drs: *drs,
             lrs: *lrs,
             dt: *dt,
-            pagesize: *pagesize
+            pagesize: Some(*pagesize),
         }
-    }   
+    }
 
     /**
      * Get the memory use of the process.
-     * 
+     *
      * ```
      * use monitoring_agent_lib::proc::statm::Statm;
      * Statm::get_meminfo();
      * ```
-     * 
+     *
      * Returns the statm data or an error.
-     * 
+     *
      * # Errors
      *  - If there is an error reading the meminfo file.
      *  - If there is an error reading a line from the meminfo file.
@@ -84,66 +89,59 @@ impl ProcsStatm {
      */
     #[tracing::instrument(level = "debug")]
     pub fn get_statm(pid: u32) -> Result<ProcsStatm, CommonLibError> {
-
         let pagesize = ProcsStatm::get_pagesize()?;
 
-        let statm_file = File::open("/proc/".to_string() + pid.to_string().as_str() + "/statm").map_err(|err| {
-            CommonLibError::new(format!("Error reading statm file: {err:?}").as_str())
-        })?;
-        ProcsStatm::read_statm(statm_file, pagesize)        
+        let statm_file = File::open("/proc/".to_string() + pid.to_string().as_str() + "/statm")
+            .map_err(|err| {
+                CommonLibError::new(format!("Error reading statm file: {err:?}").as_str())
+            })?;
+        ProcsStatm::read_statm(statm_file, pagesize)
     }
 
     /**
      * Get the pagesize.
-     * 
+     *
      * Returns the pagesize or an error.
-     * 
+     *
      * # Errors
      * - If there is an error getting the pagesize.
      */
-    fn get_pagesize() -> Result<Option<u32>, CommonLibError> {
-        let pagesize = std::process::Command::new("getconf")
-        .arg("PAGESIZE")
-        .output()
-        .map_err(|err| {
-            CommonLibError::new(format!("Error getting pagesize: {err:?}").as_str())
-        })?.stdout;    
-        let pagesize = String::from_utf8(pagesize)
-            .map_err(|err| {
-                CommonLibError::new(format!("Error parsing pagesize: {err:?}").as_str())
-            })?.trim().parse::<u32>().ok();
-        Ok(pagesize)
+    fn get_pagesize() -> Result<u32, CommonLibError> {
+        let sysconf_pagesize = unsafe { sysconf(_SC_PAGE_SIZE) };
+        sysconf_pagesize
+            .try_into()
+            .map_err(|err| CommonLibError::new(format!("Error getting pagesize: {err:?}").as_str()))
     }
-    
+
     /**
-     * Read the statm file. 
+     * Read the statm file.
      * If any data field is not parseable, it will be set to None.
-     * 
+     *
      * `file`: The file to read.
      * `pagesize`: The pagesize.
-     * 
+     *
      * Returns the statm data or an error.
-     * 
+     *
      * # Errors
      * - If there is an error reading the statm file.
      */
-    fn read_statm(file: File, pagesize: Option<u32>) -> Result<ProcsStatm, CommonLibError> {
+    fn read_statm(file: File, pagesize: u32) -> Result<ProcsStatm, CommonLibError> {
         let mut reader = BufReader::new(file);
         let mut buffer = String::new();
-        let _ =  reader.read_line(&mut buffer).map_err(|err| {
-            CommonLibError::new(format!("Error reading statm: {err:?}").as_str())
-        })?;
-        Ok(ProcsStatm::handle_statm_file(buffer.as_str(), pagesize))        
+        let _ = reader
+            .read_line(&mut buffer)
+            .map_err(|err| CommonLibError::new(format!("Error reading statm: {err:?}").as_str()))?;
+        Ok(ProcsStatm::handle_statm_file(buffer.as_str(), pagesize))
     }
 
     /**
      * Handle the statm file.
-     * 
+     *
      * `buffer`: The buffer to parse.
-     * 
+     *
      * Returns the statm data or an error.
      */
-    fn handle_statm_file(buffer: &str, pagesize: Option<u32>) -> ProcsStatm {
+    fn handle_statm_file(buffer: &str, pagesize: u32) -> ProcsStatm {
         let cols = buffer.split_whitespace().collect::<Vec<&str>>();
         let size = cols[0].parse::<u32>().ok();
         let resident = cols[1].parse::<u32>().ok();
@@ -154,7 +152,6 @@ impl ProcsStatm {
         let dt = cols[6].parse::<u32>().ok();
         ProcsStatm::new(&size, &resident, &share, &trs, &drs, &lrs, &dt, &pagesize)
     }
-
 }
 
 #[cfg(test)]
@@ -164,7 +161,7 @@ mod tests {
     #[test]
     fn test_handle_statm_from_buffer1() {
         let buffer = "5805 3442 2354 11 0 1082 0";
-        let statm = ProcsStatm::handle_statm_file(buffer, Some(4096));
+        let statm = ProcsStatm::handle_statm_file(buffer, 4096);
         assert_eq!(statm.size, Some(5805));
         assert_eq!(statm.resident, Some(3442));
         assert_eq!(statm.share, Some(2354));
@@ -173,11 +170,11 @@ mod tests {
         assert_eq!(statm.lrs, Some(0));
         assert_eq!(statm.dt, Some(0));
     }
-    
+
     #[test]
     fn test_handle_statm_buffer2() {
         let buffer = "494524 21506 2214 1471 0 59164 0";
-        let statm = ProcsStatm::handle_statm_file(buffer, Some(4096));
+        let statm = ProcsStatm::handle_statm_file(buffer, 4096);
         assert_eq!(statm.size, Some(494524));
         assert_eq!(statm.resident, Some(21506));
         assert_eq!(statm.share, Some(2214));
@@ -185,17 +182,17 @@ mod tests {
         assert_eq!(statm.drs, Some(59164));
         assert_eq!(statm.lrs, Some(0));
         assert_eq!(statm.dt, Some(0));
-    }    
+    }
 
     #[test]
     fn test_handle_statm_pid_1() {
         let statm = ProcsStatm::get_statm(1);
         assert!(statm.is_ok());
-    }  
+    }
 
     #[test]
     fn test_handle_statm_pid_0() {
         let statm = ProcsStatm::get_statm(0);
         assert!(statm.is_err());
-    }    
+    }
 }


### PR DESCRIPTION
In the case where getconf is missing, the monitoring agent will now fail to return statm information. This is because the agent cannot determine the page size of the system. This commit removes getconf and instead gets pagesize from sysconf.

Breaking changes: None

Resolves: #211