### PR TITLE
feat:Issue-215:Add warn as monitor status

### DIFF
--- a/monitoring-agent-daemon/src/api/response.rs
+++ b/monitoring-agent-daemon/src/api/response.rs
@@ -470,6 +470,8 @@ pub enum MonitorStatusResponse {
     Unknown,
     /// The monitor has an error.
     Error,
+    /// The monitor has a warning.    
+    Warn,
 }
 
 impl MonitorStatusResponse {
@@ -486,6 +488,7 @@ impl MonitorStatusResponse {
             Status::Ok => MonitorStatusResponse::Ok,
             Status::Unknown => MonitorStatusResponse::Unknown,
             Status::Error { message: _ } => MonitorStatusResponse::Error,
+            Status::Warn { message: _ } => MonitorStatusResponse::Warn,
         }
     }
 }

--- a/monitoring-agent-daemon/src/common/monitorstatus.rs
+++ b/monitoring-agent-daemon/src/common/monitorstatus.rs
@@ -56,11 +56,7 @@ impl MonitorStatus {
      */
     pub fn set_status(&mut self, status: &Status) {
         match status {
-            Status::Error { message } => {
-                self.last_error_time = Some(chrono::Utc::now());
-                self.last_error = Some(message.clone());
-            }
-            Status::Warn { message } => {
+            Status::Error { message } | Status::Warn { message } => {
                 self.last_error_time = Some(chrono::Utc::now());
                 self.last_error = Some(message.clone());
             }

--- a/monitoring-agent-daemon/src/common/monitorstatus.rs
+++ b/monitoring-agent-daemon/src/common/monitorstatus.rs
@@ -78,6 +78,7 @@ impl MonitorStatus {
  * - Error: The monitor has encountered an error. The error message is stored in the message field
  *
  */
+#[warn(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum Status {
     /// The monitor is working correctly.
@@ -87,6 +88,7 @@ pub enum Status {
     /// The monitor has encountered an error. The error message is stored in the message field.
     Error { message: String },
     /// The monitor has encountered a warning. The warning message is stored in the message field.
+    #[allow(dead_code)]
     Warn { message: String },
 }
 

--- a/monitoring-agent-daemon/src/common/monitorstatus.rs
+++ b/monitoring-agent-daemon/src/common/monitorstatus.rs
@@ -60,6 +60,10 @@ impl MonitorStatus {
                 self.last_error_time = Some(chrono::Utc::now());
                 self.last_error = Some(message.clone());
             }
+            Status::Warn { message } => {
+                self.last_error_time = Some(chrono::Utc::now());
+                self.last_error = Some(message.clone());
+            }
             Status::Ok => {
                 self.last_successful_time = Some(chrono::Utc::now());
             }
@@ -86,6 +90,8 @@ pub enum Status {
     Unknown,
     /// The monitor has encountered an error. The error message is stored in the message field.
     Error { message: String },
+    /// The monitor has encountered a warning. The warning message is stored in the message field.
+    Warn { message: String },
 }
 
 impl Status {

--- a/monitoring-agent-daemon/src/services/databaseservice.rs
+++ b/monitoring-agent-daemon/src/services/databaseservice.rs
@@ -123,6 +123,7 @@ impl DbService {
     fn get_status_db_repr(status: &Status) -> String {
         match &status {
             Status::Error { message: _ } => "ERROR".to_string(),
+            Status::Warn { message: _ } => "WARN".to_string(),
             Status::Ok => "OK".to_string(),
             Status::Unknown => "UNKNOWN".to_string(),
         }

--- a/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
@@ -132,7 +132,7 @@ impl TcpMonitor {
             }
             Err(err) => {
                 info!("Monitor status error: {} - {}", &self.name, err);
-                self.set_status(&Status::Error {
+                self.set_status(&Status::Warn {
                     message: format!(
                         "Error connecting to {}:{} with error: {err}",
                         &self.host, &self.port,

--- a/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/tcpmonitor.rs
@@ -132,7 +132,7 @@ impl TcpMonitor {
             }
             Err(err) => {
                 info!("Monitor status error: {} - {}", &self.name, err);
-                self.set_status(&Status::Warn {
+                self.set_status(&Status::Error {
                     message: format!(
                         "Error connecting to {}:{} with error: {err}",
                         &self.host, &self.port,

--- a/monitoring-agent-ui/src/components/Monitors.vue
+++ b/monitoring-agent-ui/src/components/Monitors.vue
@@ -10,6 +10,7 @@ export default {
         return {
             showErrorStatus: true,
             showOkStatus: true,
+            showWarnStatus: true,
             monitors: []
         }
     },
@@ -51,8 +52,13 @@ export default {
                 <li class="nav-item">
                     <input class="form-check-input toolbar-item" type="checkbox" id="showOErrorStatus"
                         v-model="showErrorStatus"></input>
-                    <label class="form-check-label text-light" for="showOErrorStatus">Show Error</label>
+                    <label class="form-check-label text-light" for="showErrorStatus">Show Error</label>
                 </li>
+                <li class="nav-item">
+                    <input class="form-check-input toolbar-item" type="checkbox" id="showWarnStatus"
+                        v-model="showWarnStatus"></input>
+                    <label class="form-check-label text-light" for="showWarnStatus">Show Warnings</label>
+                </li>                
                 <li class="nav-item">
                     <input class="form-check-input toolbar-item" type="checkbox" id="showOkStatus"
                         v-model="showOkStatus">
@@ -66,7 +72,7 @@ export default {
             <div class="row">
                 <template v-for="monitor in monitors">
                     <div class="col col-12 col-sm-12 col-md-12 col-lg-6 col-xl-6"
-                        v-if="(monitor.status === 'Ok' && showOkStatus) || (monitor.status === 'Error' && showErrorStatus)">
+                        v-if="(monitor.status === 'Ok' && showOkStatus) || (monitor.status === 'Error' && showErrorStatus) || (monitor.status === 'Warn' && showWarnStatus)">
                         <div class="card">
                             <div v-if="monitor.status === 'Ok'" class="card-header bg-success text-truncate">
                                 <h6 class="text-truncate title">
@@ -80,7 +86,19 @@ export default {
                                     {{ monitor.serverName }} - {{ monitor.name }}
                                 </h6>
                             </div>
-                            <div v-else="monitor.status === 'Ok'" class="card-header bg-danger text-truncate">
+                            <div v-if="monitor.status === 'Warn'" class="card-header bg-warning text-truncate">
+                                <h6 class="text-truncate title">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                        class="bi bi-shield-x" viewBox="0 0 16 16">
+                                        <path
+                                            d="M5.338 1.59a61 61 0 0 0-2.837.856.48.48 0 0 0-.328.39c-.554 4.157.726 7.19 2.253 9.188a10.7 10.7 0 0 0 2.287 2.233c.346.244.652.42.893.533q.18.085.293.118a1 1 0 0 0 .101.025 1 1 0 0 0 .1-.025q.114-.034.294-.118c.24-.113.547-.29.893-.533a10.7 10.7 0 0 0 2.287-2.233c1.527-1.997 2.807-5.031 2.253-9.188a.48.48 0 0 0-.328-.39c-.651-.213-1.75-.56-2.837-.855C9.552 1.29 8.531 1.067 8 1.067c-.53 0-1.552.223-2.662.524zM5.072.56C6.157.265 7.31 0 8 0s1.843.265 2.928.56c1.11.3 2.229.655 2.887.87a1.54 1.54 0 0 1 1.044 1.262c.596 4.477-.787 7.795-2.465 9.99a11.8 11.8 0 0 1-2.517 2.453 7 7 0 0 1-1.048.625c-.28.132-.581.24-.829.24s-.548-.108-.829-.24a7 7 0 0 1-1.048-.625 11.8 11.8 0 0 1-2.517-2.453C1.928 10.487.545 7.169 1.141 2.692A1.54 1.54 0 0 1 2.185 1.43 63 63 0 0 1 5.072.56" />
+                                        <path
+                                            d="M6.146 5.146a.5.5 0 0 1 .708 0L8 6.293l1.146-1.147a.5.5 0 1 1 .708.708L8.707 7l1.147 1.146a.5.5 0 0 1-.708.708L8 7.707 6.854 8.854a.5.5 0 1 1-.708-.708L7.293 7 6.146 5.854a.5.5 0 0 1 0-.708" />
+                                    </svg>
+                                    {{ monitor.serverName }} - {{ monitor.name }}
+                                </h6>
+                            </div>                            
+                            <div v-if="monitor.status === 'Error'" class="card-header bg-danger text-truncate">
                                 <h6 class="text-truncate title">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
                                         class="bi bi-shield-x" viewBox="0 0 16 16">


### PR DESCRIPTION
Adds warning as an additional status for monitors. This is useful for when a monitor is in a state that is not critical but still requires attention. This issue fixes both serverside and clientside.

Breaking changes: None

Resolves: #215