### PR TITLE
feat:Issue-213:Add certificate monitor

### DIFF
--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -96,6 +96,15 @@ pub enum MonitorType {
         /// Store vales in database        
         #[serde(rename = "storeValues", default = "default_as_false")]
         store_values: bool,         
+    },
+    Certificate {
+        /// The certificate to monitor.
+        #[serde(rename = "certificates")]
+        certificates: Vec<String>,
+        #[serde(rename = "thresholdDaysWarn", default = "default_threshold_days_warn")]
+        threshold_days_warn: u32,
+        #[serde(rename = "thresholdDaysError", default = "default_threshold_days_error")]
+        threshold_days_error: u32,
     }
 }
 
@@ -473,9 +482,28 @@ fn default_notify_schedule() -> String {
     "0 */5 * * * *".to_string()
 }
 
+/**
+ * Default resend error after set hours.
+ */
 fn default_resend_after() -> i64 {
     debug!("Using default resend after");
     120
+}
+
+/**
+ * Default threshold days warn.
+ */
+fn default_threshold_days_warn() -> u32 {
+    debug!("Using default threshold days warn");
+    30
+}
+
+/**
+ * Default threshold days error.
+ */
+fn default_threshold_days_error() -> u32 {
+    debug!("Using default threshold days error");
+    14
 }
 
 #[cfg(test)]

--- a/monitoring-agent-daemon/src/services/monitors/certificatemonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/certificatemonitor.rs
@@ -1,0 +1,366 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use openssl::{asn1::Asn1Time, x509::X509};
+use tokio_cron_scheduler::Job;
+use tracing::{debug, error};
+
+use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, services::{monitors::Monitor, DbService}};
+
+/**
+ * The certificate monitor.
+ * 
+ * Fields:
+ * `name`: The name.
+ * `status`: The status.
+ * `certificates`: Paths to the certificates.
+ * `threshold_days_warn`: The threshold days for a warning.
+ * `threshold_days_error`: The threshold days for an error.
+ * `database_service`: The database service.
+ * `database_store_level`: The database store level.
+ */
+#[derive(Debug, Clone)]
+pub struct CertificateMonitor {
+    /// The name of the monitor.
+    name: String,
+    /// The status.
+    status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
+    /// Paths to certificates.
+    certificates: Vec<String>,
+    /// The threshold days for a warning.
+    threshold_days_warn: u32,
+    /// The threshold days for an error.
+    threshold_days_error: u32,
+    /// The database service.
+    database_service: Arc<Option<DbService>>,   
+    /// The database store level.
+    database_store_level: DatabaseStoreLevel,     
+}
+
+impl CertificateMonitor {
+    /**
+     * Create a new certificate monitor.
+     * 
+     * `name`: The name.
+     * `description`: The description.
+     * `status`: The status.
+     * `certificates`: The certificates.
+     * `threshold_days_warn`: The threshold days for a warning.
+     * `threshold_days_error`: The threshold days for an error.
+     * `database_service`: The database service.
+     * `database_store_level`: The database store level.
+     * 
+     * Returns a new `CertificateMonitor`.
+     */
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        name: &str,
+        description: &Option<String>,
+        status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
+        certificates: Vec<String>,
+        threshold_days_warn: u32,
+        threshold_days_error: u32,
+        database_service: &Arc<Option<DbService>>,
+        database_store_level: &DatabaseStoreLevel,
+    ) -> CertificateMonitor {
+        let status_lock = status.lock();
+        match status_lock {
+            Ok(mut lock) => {
+                lock.insert(name.to_string(), MonitorStatus::new(name, description, Status::Unknown));
+            }
+            Err(err) => {
+                error!("Error creating command monitor: {:?}", err);
+            }
+        }
+        CertificateMonitor {
+            name: name.to_string(),
+            status: status.clone(),
+            certificates,
+            threshold_days_warn,
+            threshold_days_error,
+            database_service: database_service.clone(),
+            database_store_level: database_store_level.clone(),
+        }
+    }
+
+    pub fn get_certificate_job(
+        &mut self,
+        schedule: &str,   
+    ) -> Result<Job, ApplicationError>{
+        let certificate_job = self.clone();
+        let job_result = Job::new_async(schedule, move |_uuid, _locked| {
+            let mut certificate_job = certificate_job.clone();
+            Box::pin(async move {
+                let _ = certificate_job.check().await.map_err(|err| {
+                    error!("Error checking monitor: {:?}", err);
+                });
+            })
+        });
+        job_result.map_err(|err| {
+            ApplicationError::new(&format!("Error creating certificate job: {err:?}"))
+        })     
+    }
+
+    pub async fn check(&mut self) -> Result<(), ApplicationError> {
+        debug!("Checking certificates for monitor: {:?}", self.name);
+        /*
+         * Store errors and warnings in these vectors.
+         */
+        let mut vec_errors = Vec::new();
+        let mut vec_warns = Vec::new();
+        /*
+         * Get the error and warn times. If the certificates not after is less than the error time, add to errors or warnings.
+         */
+        let error_time = Asn1Time::days_from_now(self.threshold_days_error).map_err(|err| {
+            ApplicationError::new(&format!("Error getting error time: {err:?}"))
+        })?;        
+        let warn_time = Asn1Time::days_from_now(self.threshold_days_warn).map_err(|err| {
+            ApplicationError::new(&format!("Error getting warn time: {err:?}"))
+        })?;        
+        /*
+         * Loop through the certificates and check. 
+         */
+        for certificate in &self.certificates {
+            /*
+             * Read the certificate.
+             */
+            let cert = Self::read_certificate(certificate)?;
+            /*
+             * Check if the not after is less than the error time.
+             */
+            let not_after_error = Self::check_not_after(&cert, &error_time)?;
+            /*
+             * If the not after is less than the error time, add to errors.
+             */
+            if not_after_error {
+                vec_errors.push(format!("Certificate: {:?} will expire in less than {:?} days", certificate, self.threshold_days_error));
+                continue;   
+            }; 
+            /*
+             * Check if the not after is less than the warn time.
+             */           
+            let not_after_warn = Self::check_not_after(&cert, &warn_time)?;
+            /*
+             * If the not after is less than the warn time, add to warnings.
+             */
+            if not_after_warn {
+                vec_warns.push(format!("Certificate: {:?} will expire in less than {:?} days", certificate, self.threshold_days_warn));
+                continue;   
+            };                
+        };
+        /*
+         * Set the status.
+         */
+        self.set_status_info(vec_errors, vec_warns).await;
+        Ok(())
+    }
+
+    /**
+     * Set the status.
+     * 
+     * `vec_errors`: Errors found.
+     * `vec_warns`: Warnings found.
+     */
+    async fn set_status_info(&mut self, vec_errors: Vec<String>, vec_warns: Vec<String>) {
+        if !vec_errors.is_empty() {
+            self.set_status(&Status::Error { message: vec_errors.join("\n") + "\n" + vec_warns.join("\n").as_str() }).await;
+        } else if !vec_warns.is_empty() {
+            self.set_status(&Status::Warn { message: vec_warns.join("\n") }).await;
+        } else {
+            self.set_status(&Status::Ok).await;
+        }
+    }
+
+    /**
+     * Read the certificate.
+     * 
+     * `certificate`: The certificate.
+     * 
+     * Returns: The certificate.
+     * 
+     * Errors:
+     * - Error reading certificate.
+     * - Error parsing certificate.
+     */
+    fn read_certificate(certificate: &String) -> Result<X509, ApplicationError> {
+        let cert_vec = std::fs::read(certificate).map_err(|err| {
+            ApplicationError::new(&format!("Error reading certificate: {err:?}"))
+        })?;
+        let cert = X509::from_pem(&cert_vec).map_err(|err| {
+            ApplicationError::new(&format!("Error parsing certificate: {err:?}"))
+        })?;
+        Ok(cert)
+    }
+
+    /**
+     * Check if the certificate is older than the error time.
+     * 
+     * `cert`: The certificate.
+     * `check_time`: The error time.
+     * 
+     * Returns: True if the certificate not after is less than the error time.
+     * 
+     * Errors:
+     * - Error comparing certificate not after to error threshold.
+     */
+    fn check_not_after(cert: &X509, check_time: &Asn1Time) -> Result<bool, ApplicationError> {
+        let not_after_error = cert.not_after().compare(check_time).map_err(|err| {
+            ApplicationError::new(&format!("Error comparing certificate not after to error threshold: {err:?}"))
+        })?;
+        Ok(not_after_error.is_le())
+    }    
+}
+
+/**
+ * Implement the `Monitor` trait for `CertificateMonitor`.
+ */
+impl super::Monitor for CertificateMonitor {
+    /**
+     * Get the name of the monitor.
+     *
+     * Returns: The name of the monitor.
+     */
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /**
+     * Get the status of the monitor.
+     *
+     * Returns: The status of the monitor.
+     */
+    fn get_status(&self) -> Arc<Mutex<HashMap<String, MonitorStatus>>> {
+        self.status.clone()
+    }
+
+    /**
+     * Get the database service.
+     *
+     * Returns: The database service.
+     */
+    fn get_database_service(&self) -> Arc<Option<DbService>> {
+        self.database_service.clone()
+    }
+ 
+    /**
+     * Get the database store level.
+     *
+     * Returns: The database store level.
+     */
+    fn get_database_store_level(&self) -> DatabaseStoreLevel {
+        self.database_store_level.clone()
+    }   
+
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_read_certificate() {
+        let certificate = "resources/test/client_cert/client.cer".to_string();
+        let result = CertificateMonitor::read_certificate(&certificate);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_check_not_after() {        
+        let mut cert = X509::builder().unwrap();
+        cert.set_not_after(Asn1Time::days_from_now(1).unwrap().as_ref()).unwrap();    
+        let cert = cert.build();    
+        let check_time_before = Asn1Time::days_from_now(0).unwrap();
+        let result_before = CertificateMonitor::check_not_after(&cert, &check_time_before).unwrap();
+        assert!(!result_before);
+        let check_time_after = Asn1Time::days_from_now(2).unwrap();
+        let result_after = CertificateMonitor::check_not_after(&cert, &check_time_after).unwrap();
+        assert!(result_after);        
+    }
+
+    #[tokio::test]
+    async fn test_set_status_info_both_err_and_warn() {
+        let mut certificate_monitor = CertificateMonitor::new(
+            "test",
+            &None,
+            &Arc::new(Mutex::new(HashMap::new())),
+            vec!["resources/test/client_cert/client.cer".to_string()],
+            1,
+            2,
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+        );
+        let vec_errors = vec!["Error".to_string()];
+        let vec_warns = vec!["Warning".to_string()];
+        certificate_monitor.set_status_info(vec_errors, vec_warns).await;
+        let status = certificate_monitor.get_status();
+        let status_lock = status.lock().unwrap();
+        let monitor_status = status_lock.get("test").unwrap();
+        assert_eq!(monitor_status.status, Status::Error { message: "Error\nWarning".to_string() });
+    }
+
+    #[tokio::test]
+    async fn test_set_status_info_err() {
+        let mut certificate_monitor = CertificateMonitor::new(
+            "test",
+            &None,
+            &Arc::new(Mutex::new(HashMap::new())),
+            vec!["resources/test/client_cert/client.cer".to_string()],
+            1,
+            2,
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+        );
+        let vec_errors = vec!["Error".to_string()];
+        let vec_warns = vec![];
+        certificate_monitor.set_status_info(vec_errors, vec_warns).await;
+        let status = certificate_monitor.get_status();
+        let status_lock = status.lock().unwrap();
+        let monitor_status = status_lock.get("test").unwrap();
+        assert_eq!(monitor_status.status, Status::Error { message: "Error\n".to_string() });
+    } 
+
+    #[tokio::test]
+    async fn test_set_status_info_warn() {
+        let mut certificate_monitor = CertificateMonitor::new(
+            "test",
+            &None,
+            &Arc::new(Mutex::new(HashMap::new())),
+            vec!["resources/test/client_cert/client.cer".to_string()],
+            1,
+            2,
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+        );
+        let vec_errors = vec![];
+        let vec_warns = vec!["Warn".to_string()];
+        certificate_monitor.set_status_info(vec_errors, vec_warns).await;
+        let status = certificate_monitor.get_status();
+        let status_lock = status.lock().unwrap();
+        let monitor_status = status_lock.get("test").unwrap();
+        assert_eq!(monitor_status.status, Status::Warn { message: "Warn".to_string() });
+    }  
+
+    #[tokio::test]
+    async fn test_set_status_info_none() {
+        let mut certificate_monitor = CertificateMonitor::new(
+            "test",
+            &None,
+            &Arc::new(Mutex::new(HashMap::new())),
+            vec!["resources/test/client_cert/client.cer".to_string()],
+            1,
+            2,
+            &Arc::new(None),
+            &DatabaseStoreLevel::None,
+        );
+        let vec_errors = vec![];
+        let vec_warns = vec![];
+        certificate_monitor.set_status_info(vec_errors, vec_warns).await;
+        let status = certificate_monitor.get_status();
+        let status_lock = status.lock().unwrap();
+        let monitor_status = status_lock.get("test").unwrap();
+        assert_eq!(monitor_status.status, Status::Ok);
+    }              
+
+
+
+}

--- a/monitoring-agent-daemon/src/services/monitors/mod.rs
+++ b/monitoring-agent-daemon/src/services/monitors/mod.rs
@@ -10,6 +10,7 @@
  * `systemctlmonitor`: Monitor that checks the status of a systemd service.
  * `databasemonitor`: Monitor that checks the status of a database service.
  * `processmonitor`: Monitor that checks the status of a process.
+ * `certificatemonitor`: Monitor that checks the status of a certificate.
  */
 mod common;
 mod commandmonitor;
@@ -20,6 +21,7 @@ mod meminfomonitor;
 mod systemctlmonitor;
 mod databasemonitor;
 mod processmonitor;
+mod certificatemonitor;
 
 pub use common::Monitor;
 pub use commandmonitor::CommandMonitor;
@@ -30,3 +32,4 @@ pub use meminfomonitor::MeminfoMonitor;
 pub use systemctlmonitor::SystemctlMonitor;
 pub use databasemonitor::DatabaseMonitor;
 pub use processmonitor::ProcessMonitor;
+pub use certificatemonitor::CertificateMonitor;


### PR DESCRIPTION
Implements a certificate monitor that checks the expiration date of a certificate and sends an alert if it is about to expire. The monitor schedule is configurable and can be set to run at a specific time or interval.

The following is configurable for the certificate monitor:
- The certificate file path (Multiple certificates can be monitored)
- The expiration threshold in days (Both warn and error thresholds)
- The schedule for the monitor

Breaking changes: None

Resolves: #213