### PR TITLE
feat:Issue-214:Thresholds process monitor

### DIFF
--- a/monitoring-agent-daemon/resources/test/configuration_import_test/test_simple_process.json
+++ b/monitoring-agent-daemon/resources/test/configuration_import_test/test_simple_process.json
@@ -10,7 +10,8 @@
             "details": {
                 "type": "process",
                 "applicationNames": ["app1", "app2"],
-                "maxMemUsage": 100,
+                "thresholdMemWarn": 100,
+                "thresholdMemError": 100,
                 "storeValues": true
             }
         }

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -89,10 +89,13 @@ pub enum MonitorType {
         pids: Option<Vec<u32>>,
         /// Regexp on name.
         #[serde(rename = "regexp")] 
-        regexp: Option<String>,        
-        /// The maximum memory usage.
-        #[serde(skip_serializing_if = "Option::is_none", rename = "maxMemUsage")]
-        max_mem_usage: Option<u32>,        
+        regexp: Option<String>,     
+        /// The maximum memory before warn.
+        #[serde(skip_serializing_if = "Option::is_none", rename = "thresholdMemWarn")]
+        threshold_mem_warn: Option<u64>,                 
+        /// The maximum memory before error.
+        #[serde(skip_serializing_if = "Option::is_none", rename = "thresholdMemError")]
+        threshold_mem_error: Option<u64>,        
         /// Store vales in database        
         #[serde(rename = "storeValues", default = "default_as_false")]
         store_values: bool,         
@@ -724,7 +727,8 @@ mod tests {
                 application_names: Some(vec!["app1".to_string(), "app2".to_string()]),
                 pids: None,
                 regexp: None,
-                max_mem_usage: Some(100),
+                threshold_mem_error: Some(100),
+                threshold_mem_warn: Some(100),                
                 store_values: true,
                 
             }

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -241,9 +241,9 @@ impl SchedulingService {
                 let job = database_monitor.get_database_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
-            crate::common::MonitorType::Process { application_names, pids, regexp, max_mem_usage, store_values 
+            crate::common::MonitorType::Process { application_names, pids, regexp, threshold_mem_warn, threshold_mem_error, store_values 
             } => {
-                let mut process_monitor = ProcessMonitor::new(&monitor.name, &monitor.description, application_names, pids, regexp, max_mem_usage, &self.status, &self.database_service.clone(), &monitor.store, store_values);
+                let mut process_monitor = ProcessMonitor::new(&monitor.name, &monitor.description, application_names, pids, regexp, threshold_mem_warn, threshold_mem_error, &self.status, &self.database_service.clone(), &monitor.store, store_values);
                 let job = process_monitor.get_process_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },


### PR DESCRIPTION
Changes the process monitor to use threshold vales rather than only a max value. This allows for more flexibility in the configuration of the monitor. It has threshold for error and warn. If the process exceeds the error threshold, the monitor will return an error. If the process exceeds the warn threshold, the monitor will return a warning. If the process is below the warn threshold, the monitor will return ok.

Breaking changes: max value is no longer used and will cause the agent to fail to startup if it is used in the configuration.

Resolves: #214