### PR TITLE
feat:Issue-217:Thresholds loadaverage

### DIFF
--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -58,6 +58,12 @@ pub enum MonitorType {
         threshold_5min: Option<f32>,
         #[serde(skip_serializing_if = "Option::is_none", rename = "threshold15min")]
         threshold_15min: Option<f32>,
+        #[serde(rename = "threshold1minLevel", default = "default_threshold_level")]
+        threshold_1min_level: ThresholdLevel,
+        #[serde(rename = "threshold5minLevel", default = "default_threshold_level")]
+        threshold_5min_level: ThresholdLevel,
+        #[serde(rename = "threshold15minLevel", default = "default_threshold_level")]
+        threshold_15min_level: ThresholdLevel,        
         #[serde(rename = "storeValues", default = "default_as_false")]
         store_values: bool,    
     },  
@@ -109,6 +115,15 @@ pub enum MonitorType {
         #[serde(rename = "thresholdDaysError", default = "default_threshold_days_error")]
         threshold_days_error: u32,
     }
+}
+
+/**
+ * Threshold level.
+ */
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Copy)]
+pub enum ThresholdLevel {
+    Warn,
+    Error,
 }
 
 /**
@@ -393,6 +408,10 @@ fn default_server() -> ServerConfig {
     }
 }
 
+fn default_threshold_level() -> ThresholdLevel {
+    ThresholdLevel::Error
+}
+
 /**
  * Default server workers.
  * 
@@ -663,6 +682,9 @@ mod tests {
                 threshold_1min: Some(1.0),
                 threshold_5min: Some(2.0),
                 threshold_15min: Some(3.0),
+                threshold_1min_level: ThresholdLevel::Error,
+                threshold_5min_level: ThresholdLevel::Error,
+                threshold_15min_level: ThresholdLevel::Error,
                 store_values: true,               
             }
         );

--- a/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/loadavgmonitor.rs
@@ -4,9 +4,17 @@ use log::{debug, error, info};
 use monitoring_agent_lib::proc::ProcsLoadavg;
 use tokio_cron_scheduler::Job;
 
-use crate::{common::{configuration::DatabaseStoreLevel, ApplicationError, MonitorStatus, Status}, DbService};
+use crate::{common::{configuration::{DatabaseStoreLevel, ThresholdLevel}, ApplicationError, MonitorStatus, Status}, DbService};
 
 use super::Monitor;
+/**
+ * Values for the status of the monitor to identify
+ * the highest state.
+ */
+const ERROR: u8 = 2;
+const WARN: u8 = 1;
+const OK: u8 = 0;
+
 /**
  * Load average monitor.
  * 
@@ -17,6 +25,9 @@ use super::Monitor;
  * `loadavg1min_max`: The max load average for 1 minute.
  * `loadavg5min_max`: The max load average for 5 minutes.
  * `loadavg15min_max`: The max load average for 10 minutes.
+ * `threshold_1min_level`: The threshold for the 1 minute load average.
+ * `threshold_5min_level`: The threshold for the 5 minute load average.
+ * `threshold_15min_level`: The threshold for the 15 minute load average.
  * `status`: The status of the monitor.
  * `database_service`: The database service.
  * `database_store_level`: The database store level.
@@ -33,6 +44,12 @@ pub struct LoadAvgMonitor {
     pub loadavg5min_max: Option<f32>,
     /// Max load average for 10 minutes.
     pub loadavg15min_max: Option<f32>,
+    /// The threshold for the 1 minute load average.
+    pub threshold_1min_level: ThresholdLevel,
+    /// The threshold for the 5 minute load average.
+    pub threshold_5min_level: ThresholdLevel,
+    /// The threshold for the 15 minute load average.
+    pub threshold_15min_level: ThresholdLevel,    
     /// The status of the monitor.
     pub status: Arc<Mutex<HashMap<String, MonitorStatus>>>,
     /// The database service.
@@ -52,6 +69,9 @@ impl LoadAvgMonitor {
      * `loadavg1min_max`: The max load average for 1 minute.
      * `loadavg5min_max`: The max load average for 5 minutes.
      * `loadavg15min_max`: The max load average for 10 minutes.
+     * `threshold_1min_level`: The threshold for the 1 minute load average.
+     * `threshold_5min_level`: The threshold for the 5 minute load average.
+     * `threshold_15min_level`: The threshold for the 15 minute load average.
      * `status`: The status of the monitor.
      * `database_service`: The database service.
      * `database_store_level`: The database store level.
@@ -68,6 +88,9 @@ impl LoadAvgMonitor {
         loadavg1min_max: Option<f32>,
         loadavg5min_max: Option<f32>,
         loadavg15min_max: Option<f32>,
+        threshold_1min_level: ThresholdLevel,
+        threshold_5min_level: ThresholdLevel,
+        threshold_15min_level: ThresholdLevel,
         status: &Arc<Mutex<HashMap<String, MonitorStatus>>>,
         database_service: &Arc<Option<DbService>>,
         database_store_level: &DatabaseStoreLevel,
@@ -89,6 +112,9 @@ impl LoadAvgMonitor {
             loadavg1min_max,
             loadavg5min_max,
             loadavg15min_max,
+            threshold_1min_level,
+            threshold_5min_level,
+            threshold_15min_level,
             status: status.clone(),
             database_service: database_service.clone(),
             database_store_level: database_store_level.clone(),
@@ -104,19 +130,65 @@ impl LoadAvgMonitor {
      */
     #[allow(clippy::similar_names)]         
     async fn check_loadavg(&mut self, loadavg: &ProcsLoadavg) {    
-        let status_1min = LoadAvgMonitor::check_loadavg_values(self.loadavg1min_max, loadavg.loadavg1min);
-        let status_5min = LoadAvgMonitor::check_loadavg_values(self.loadavg5min_max, loadavg.loadavg5min);
-        let status_15min = LoadAvgMonitor::check_loadavg_values(self.loadavg15min_max, loadavg.loadavg15min);
-        
-        if status_1min != Status::Ok || status_5min != Status::Ok || status_15min != Status::Ok {
-            self.set_status(&Status::Error {
-                message: format!(
-                    "Load average check failed: 1min: {status_1min:?}, 5min: {status_5min:?}, 15min: {status_15min:?}"
-                ),
-            }).await;
-        } else {
-            self.set_status(&Status::Ok).await;
+        let status_1min = Self::check_loadavg_values(self.loadavg1min_max, loadavg.loadavg1min, self.threshold_1min_level);
+        let status_5min = Self::check_loadavg_values(self.loadavg5min_max, loadavg.loadavg5min, self.threshold_5min_level);
+        let status_15min = Self::check_loadavg_values(self.loadavg15min_max, loadavg.loadavg15min, self.threshold_15min_level);        
+        let max_level = Self::get_max_error(&status_1min, &status_5min, &status_15min);
+        self.set_monitor_status(max_level, &status_1min, &status_5min, &status_15min).await;   
+
+    }
+
+    /**
+     * Set the status of the monitor based on the max level.
+     * 
+     * `max_level`: The status of the monitor.
+     * `status_1min`: The status of the 1 minute load average.
+     * `status_5min`: The status of the 5 minute load average.
+     * `status_15min`: The status of the 15 minute load average.
+     * 
+     */
+    #[allow(clippy::similar_names)]
+    async fn set_monitor_status(&mut self, max_level: u8, status_1min: &Status, status_5min: &Status, status_15min: &Status) {
+        match max_level {
+            ERROR => {
+                self.set_status(&Status::Error {
+                    message: format!(
+                        "Load average check failed: 1min: {status_1min:?}, 5min: {status_5min:?}, 15min: {status_15min:?}"
+                    ),
+                }).await;
+            }
+            WARN => {
+                self.set_status(&Status::Warn {
+                    message: format!(
+                        "Load average check failed: 1min: {status_1min:?}, 5min: {status_5min:?}, 15min: {status_15min:?}"
+                    ),
+                }).await;
+            }
+            OK => {
+                self.set_status(&Status::Ok).await;
+            }
+            _ => {
+                self.set_status(&Status::Unknown).await;
+            }
         }
+    }
+    
+    /**
+     * Get the max level of the status.
+     * 
+     * `status_1min`: The status of the 1 minute load average.
+     * `status_5min`: The status of the 5 minute load average.
+     * `status_15min`: The status of the 15 minute load average.
+     * 
+     * Returns: The max error level.
+     */
+    #[allow(clippy::similar_names)]
+    fn get_max_error(status_1min: &Status, status_5min: &Status, status_15min: &Status) -> u8 {
+        let mut max = 0;
+        Self::check_max_status(status_1min, &mut max);
+        Self::check_max_status(status_5min, &mut max);
+        Self::check_max_status(status_15min, &mut max);
+        max
     }
 
     /**
@@ -128,16 +200,27 @@ impl LoadAvgMonitor {
      * Returns: The status of the check.
      * 
      */
-    fn check_loadavg_values(max: Option<f32>, current: Option<f32>) -> Status {
+    fn check_loadavg_values(max: Option<f32>, current: Option<f32>, threshold_level : ThresholdLevel) -> Status {
         let Some(current) = current else { return Status::Ok };
         let Some(max) = max else { return Status::Ok };
             
         if current > max {
-            return Status::Error {
-                message: format!(
-                    "Load average {current} is greater than max load average {max}"
-                ),
-            };
+            match threshold_level {
+                ThresholdLevel::Error => {
+                    return Status::Error {
+                        message: format!(
+                            "Load average {current} is greater than max load average {max}"
+                        ),
+                    };
+                }
+                ThresholdLevel::Warn => {
+                    return Status::Warn {
+                        message: format!(
+                            "Load average {current} is greater than max load average {max}"
+                        ),
+                    };
+                }
+            }
         }
         Status::Ok       
     }
@@ -223,7 +306,28 @@ impl LoadAvgMonitor {
         }                    
     }    
 
+    /**
+     * Check if the current status is higher than the current.
+     * 
+     * `status`: The status of the monitor.
+     * `current`: The current status value.
+     * 
+     */
+    fn check_max_status(status: &Status, current: &mut u8) {
+        match status {
+            Status::Error { message: _ } => {
+                *current = std::cmp::max(*current, ERROR);
+            }
+            Status::Warn { message: _ } => {
+                *current = std::cmp::max(*current, WARN);
+            }
+            _ => {}
+        }
+    }    
+
 }
+
+
 
 /**
  * Implement the `Monitor` trait for `LoadAvgMonitor`.
@@ -270,7 +374,7 @@ impl super::Monitor for LoadAvgMonitor {
 #[cfg(test)]
 mod test {
     use std::{collections::HashMap, sync::{Arc, Mutex}};
-    use crate::{common::{configuration::DatabaseStoreLevel, MonitorStatus}, services::monitors::LoadAvgMonitor};
+    use crate::{common::{configuration::{DatabaseStoreLevel, ThresholdLevel}, MonitorStatus}, services::monitors::LoadAvgMonitor};
 
     use super::Monitor;
 
@@ -286,21 +390,21 @@ mod test {
      */
     #[test]
     fn test_check_loadavg_values() {
-        let status = LoadAvgMonitor::check_loadavg_values(Some(1.0), Some(1.0));
+        let status = LoadAvgMonitor::check_loadavg_values(Some(1.0), Some(1.0), ThresholdLevel::Error);
         assert_eq!(status, super::Status::Ok);
 
-        let status = LoadAvgMonitor::check_loadavg_values(Some(1.0), Some(2.0));
+        let status = LoadAvgMonitor::check_loadavg_values(Some(1.0), Some(2.0), ThresholdLevel::Error);
         assert_eq!(status, super::Status::Error {
             message: "Load average 2 is greater than max load average 1".to_string()
         });
 
-        let status: crate::common::Status = LoadAvgMonitor::check_loadavg_values(Some(1.0), None);
+        let status: crate::common::Status = LoadAvgMonitor::check_loadavg_values(Some(1.0), None, ThresholdLevel::Error);
         assert_eq!(status, super::Status::Ok);
 
-        let status = LoadAvgMonitor::check_loadavg_values(None, Some(1.0));
+        let status = LoadAvgMonitor::check_loadavg_values(None, Some(1.0), ThresholdLevel::Error);
         assert_eq!(status, super::Status::Ok);
 
-        let status = LoadAvgMonitor::check_loadavg_values(None, None);
+        let status = LoadAvgMonitor::check_loadavg_values(None, None, ThresholdLevel::Error);
         assert_eq!(status, super::Status::Ok);
     }
 
@@ -319,6 +423,9 @@ mod test {
             Some(1.0),
             Some(2.0),
             Some(3.0),
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,
@@ -355,6 +462,9 @@ mod test {
             Some(1.0),
             Some(2.0),
             Some(3.0),
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,
@@ -385,12 +495,15 @@ mod test {
     #[tokio::test]
     async fn test_check_loadavg_5min_higher() {
         // Test success. Loadaverage lower on all
-        let mut monitor = super::LoadAvgMonitor::new(
+        let mut monitor = LoadAvgMonitor::new(
             "test",
             &None,
             Some(1.0),
             Some(2.0),
             Some(3.0),
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,
@@ -421,12 +534,15 @@ mod test {
     #[tokio::test]
     async fn test_check_loadavg_15min_higher() {
         // Test success. Loadaverage lower on all
-        let mut monitor = super::LoadAvgMonitor::new(
+        let mut monitor = LoadAvgMonitor::new(
             "test",
             &None,
             Some(1.0),
             Some(2.0),
             Some(3.0),
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,
@@ -458,6 +574,9 @@ mod test {
             Some(1.0),
             Some(2.0),
             Some(3.0),
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
+            ThresholdLevel::Error,
             &status,
             &Arc::new(None),
             &DatabaseStoreLevel::None,

--- a/monitoring-agent-daemon/src/services/schedulingservice.rs
+++ b/monitoring-agent-daemon/src/services/schedulingservice.rs
@@ -210,9 +210,12 @@ impl SchedulingService {
                 threshold_1min,
                 threshold_5min,
                 threshold_15min,
+                threshold_1min_level,
+                threshold_5min_level,
+                threshold_15min_level,
                 store_values,
             } => {               
-                let mut loadavg_monitor = LoadAvgMonitor::new(&monitor.name, &monitor.description, threshold_1min, threshold_5min, threshold_15min, &self.status, &self.database_service.clone(), &monitor.store, store_values);
+                let mut loadavg_monitor = LoadAvgMonitor::new(&monitor.name, &monitor.description, threshold_1min, threshold_5min, threshold_15min, threshold_1min_level, threshold_5min_level, threshold_15min_level, &self.status, &self.database_service.clone(), &monitor.store, store_values);
                 let job = loadavg_monitor.get_loadavg_monitor_job(monitor.schedule.as_str())?;
                 self.add_job(scheduler, job).await
             },
@@ -313,7 +316,7 @@ mod test {
 
     use std::sync::Arc;
 
-    use crate::common::configuration::DatabaseStoreLevel;
+    use crate::common::configuration::{DatabaseStoreLevel, ThresholdLevel};
 
     use super::*;
 
@@ -514,6 +517,9 @@ mod test {
                 threshold_1min: Some(0.0),
                 threshold_5min: Some(0.0),
                 threshold_15min: Some(0.0),
+                threshold_1min_level: ThresholdLevel::Warn,
+                threshold_5min_level: ThresholdLevel::Warn,
+                threshold_15min_level: ThresholdLevel::Warn,
                 store_values: false,
             },
         }, &JobScheduler::new().await.unwrap()).await;


### PR DESCRIPTION
Adds threshold level for each of the load average values. The thresholds are configurable in the configuration file. The thresholds are used to determine the status of the load average values. It can be Error or Warn. Default is Error.

Breaking changes: None

Resolves: #217