### PR TITLE
feat:Issue-225:Add warning thresholds on memory monitor

### DIFF
--- a/monitoring-agent-daemon/resources/test/configuration_import_test/test_simple_meminfo.json
+++ b/monitoring-agent-daemon/resources/test/configuration_import_test/test_simple_meminfo.json
@@ -9,8 +9,10 @@
             "schedule": "0 0 0 0 0 0 0",
             "details": {
                 "type": "mem",
-                "maxPercentageMemUsed": 70.0,
-                "maxPercentageSwapUsed": 80.0,
+                "errorPercentageMemUsed": 80.0,
+                "errorPercentageSwapUsed": 70.0,
+                "warnPercentageMemUsed": 60.0,
+                "warnPercentageSwapUsed": 50.0,
                 "storeValues": true
             }
         }

--- a/monitoring-agent-daemon/src/common/configuration.rs
+++ b/monitoring-agent-daemon/src/common/configuration.rs
@@ -68,10 +68,14 @@ pub enum MonitorType {
         store_values: bool,    
     },  
     Mem {
-        #[serde(skip_serializing_if = "Option::is_none", rename = "maxPercentageMemUsed")]
-        max_percentage_mem: Option<f64>,
-        #[serde(skip_serializing_if = "Option::is_none", rename = "maxPercentageSwapUsed")]
-        max_percentage_swap: Option<f64>,        
+        #[serde(skip_serializing_if = "Option::is_none", rename = "errorPercentageMemUsed")]
+        error_percentage_used_mem: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "errorPercentageSwapUsed")]
+        error_percentage_used_swap: Option<f64>,   
+        #[serde(skip_serializing_if = "Option::is_none", rename = "warnPercentageMemUsed")]
+        warn_percentage_used_mem: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "warnPercentageSwapUsed")]
+        warn_percentage_used_swap: Option<f64>,                       
         #[serde(rename = "storeValues", default = "default_as_false")]
         store_values: bool,    
     },   
@@ -705,8 +709,10 @@ mod tests {
         assert_eq!(
             monitor,
             MonitorType::Mem {
-                max_percentage_mem: Some(70.0),
-                max_percentage_swap: Some(80.0),
+                error_percentage_used_mem: Some(80.0),
+                error_percentage_used_swap: Some(70.0),
+                warn_percentage_used_mem: Some(60.0),
+                warn_percentage_used_swap: Some(50.0),
                 store_values: true,                            
             }
         );

--- a/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
+++ b/monitoring-agent-daemon/src/services/monitors/meminfomonitor.rs
@@ -25,9 +25,13 @@ pub struct MeminfoMonitor {
     /// The name of the monitor.
     pub name: String,   
     /// Minimum free percentage memory.
-    pub max_percentage_mem: Option<f64>,
+    pub error_percentage_used_mem: Option<f64>,
     /// Minimum free percentage swap memory.
-    pub max_percentage_swap: Option<f64>,
+    pub error_percentage_used_swap: Option<f64>,
+    /// Warn free percentage memory.
+    pub warn_percentage_used_mem: Option<f64>,
+    /// Warn free percentage swap memory.
+    pub warn_percentage_used_swap: Option<f64>,    
     /// The status of the monitor.
     pub status: MonitorStatusType,    
     /// The database service
@@ -44,8 +48,10 @@ impl MeminfoMonitor {
      * Create a new `MeminfoMonitor`.
      * 
      * `name`: The name of the monitor.
-     * `max_percentage_mem`: The maximum percentage memory.
-     * `max_percentage_swap`: The maximum percentage swap.
+     * `error_percentage_used_mem`: The maximum percentage memory.
+     * `error_percentage_used_swap`: The maximum percentage swap.
+     * `warn_percentage_used_mem`: The warn percentage memory.
+     * `warn_percentage_used_swap`: The warn percentage swap. 
      * `status`: The status of the monitor.
      * `database_service`: The database service.
      * `database_store_level`: The database store level.
@@ -59,8 +65,10 @@ impl MeminfoMonitor {
     pub fn new(
         name: &str,
         description: &Option<String>,
-        max_percentage_mem: Option<f64>,
-        max_percentage_swap: Option<f64>,
+        error_percentage_used_mem: Option<f64>,
+        error_percentage_used_swap: Option<f64>,
+        warn_percentage_used_mem: Option<f64>,
+        warn_percentage_used_swap: Option<f64>,        
         status: &MonitorStatusType,
         database_service: &DatabaseServiceType,
         database_store_level: &DatabaseStoreLevel,
@@ -79,8 +87,10 @@ impl MeminfoMonitor {
 
         MeminfoMonitor {
             name: name.to_string(),
-            max_percentage_mem,
-            max_percentage_swap,
+            error_percentage_used_mem,
+            error_percentage_used_swap,
+            warn_percentage_used_mem,
+            warn_percentage_used_swap,
             status: status.clone(),
             database_service: database_service.clone(),
             database_store_level: database_store_level.clone(),
@@ -99,39 +109,48 @@ impl MeminfoMonitor {
         let percentage_mem_used = ProcsMeminfo::get_percent_used(meminfo.memfree, meminfo.memtotal);
         let percentage_swap_used = ProcsMeminfo::get_percent_used(meminfo.swapfree, meminfo.swaptotal);
 
-        let free_percentage_mem_status = MeminfoMonitor::check_meminfo_values(self.max_percentage_mem, percentage_mem_used);
-        let free_percentage_swap_status = MeminfoMonitor::check_meminfo_values(self.max_percentage_swap, percentage_swap_used);
+        let free_percentage_mem_status = MeminfoMonitor::check_meminfo_values(self.error_percentage_used_mem, self.warn_percentage_used_mem, percentage_mem_used);
+        let free_percentage_swap_status = MeminfoMonitor::check_meminfo_values(self.error_percentage_used_swap, self.warn_percentage_used_swap, percentage_swap_used);
         
         if free_percentage_mem_status != Status::Ok || free_percentage_swap_status != Status::Ok{
             self.set_status(&Status::Error {
                 message: format!(
-                    "Meminfo check failed: mem: {free_percentage_mem_status:?}, swap: {free_percentage_swap_status:?}"
+                    "Memory check failed: {free_percentage_mem_status:?}, swap: {free_percentage_swap_status:?}"
                 ),
             }).await;
-        } else {
-            self.set_status(&Status::Ok).await;
-        }
+            return;
+        }         
+        self.set_status(&Status::Ok).await;        
     }
 
     /**
-     * Check the load average values.
+     * Check the memory values.
      * 
-     * `max`: The max load average.
+     * `error`: The error threshold.
+     * `warn`: The warning threshold menory use.
      * `current`: The current load average.
      * 
      * Returns: The status of the check.
      * 
      */
-    fn check_meminfo_values(max: Option<f64>, current: Option<f64>) -> Status {
+    fn check_meminfo_values(error: Option<f64>, warn: Option<f64>, current: Option<f64>) -> Status {
         let Some(current) = current else { return Status::Ok };
-        let Some(max) = max else { return Status::Ok };
-            
-        if current > max {
-            return Status::Error {
-                message: format!(
-                    "Memory use {current:0.3}% is more than {max:0.3}%"
-                ),
-            };
+        if let Some(error) = error {    
+            if current > error {
+                return Status::Error {
+                    message: format!(
+                        "Error memory use {current:0.2}% is more than {error:0.2}%"
+                    ),
+                };
+            }
+        } else if let Some(warn) = warn {
+            if current > warn {
+                return Status::Warn {
+                    message: format!(
+                        "Warning memory use {current:0.2}% is more than {warn:0.2}%"
+                    ),
+                };
+            }            
         }
         Status::Ok       
     }
@@ -268,6 +287,8 @@ mod test {
             &None,
             Some(100.0),
             Some(100.0),
+            Some(90.0),
+            Some(90.0),            
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,
@@ -293,6 +314,8 @@ mod test {
             &None,
             Some(80.0),
             Some(80.0),
+            Some(60.0),
+            Some(60.0),            
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,
@@ -329,6 +352,8 @@ mod test {
             &None,
             Some(70.0),
             Some(15.0),
+            Some(60.0),
+            Some(10.0),            
             &Arc::new(Mutex::new(HashMap::new())),
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,
@@ -347,7 +372,7 @@ mod test {
 
         let status = monitor.get_status();
         let status = status.lock().unwrap();
-        assert_eq!(status.get("test").unwrap().status, super::Status::Error { message: "Meminfo check failed: mem: Error { message: \"Memory use 75.000% is more than 70.000%\" }, swap: Error { message: \"Memory use 50.000% is more than 15.000%\" }".to_string() });
+        assert_eq!(status.get("test").unwrap().status, super::Status::Error { message: "Memory check failed: Error { message: \"Error memory use 75.00% is more than 70.00%\" }, swap: Error { message: \"Error memory use 50.00% is more than 15.00%\" }".to_string() });
     }
 
     #[test]
@@ -359,6 +384,8 @@ mod test {
             &None,
             Some(100.0),
             Some(100.0),
+            Some(100.0),
+            Some(100.0),            
             &status,
             &Arc::new(None),
             &super::DatabaseStoreLevel::None,


### PR DESCRIPTION
Updates the memory monitor to have both error and warning thresholds. Both are implemented for memory and swap.

Breaking changes: None

Resolves: #225